### PR TITLE
Add pre-commit configuration and Ruff settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+
+  - repo: https://github.com/tcort/markdown-link-check
+    rev: v3.13.6
+    hooks:
+      - id: markdown-link-check
+        args: [-q]
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.5
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/numpy/numpydoc
+    rev: v1.8.0
+    hooks:
+      - id: numpydoc-validation
+        files: ^cbrain_cli/
+        exclude: ^(capture_tests/|.*__init__\.py$)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,9 +19,9 @@ repos:
         args: [--fix]
       - id: ruff-format
 
-  - repo: https://github.com/numpy/numpydoc
-    rev: v1.8.0
-    hooks:
-      - id: numpydoc-validation
-        files: ^cbrain_cli/
-        exclude: ^(capture_tests/|.*__init__\.py$)
+  # - repo: https://github.com/numpy/numpydoc
+  #   rev: v1.8.0
+  #   hooks:
+  #     - id: numpydoc-validation
+  #       files: ^cbrain_cli/
+  #       exclude: ^(capture_tests/|.*__init__\.py$)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.ruff]
+line-length = 100
+target-version = "py37"
+
+[tool.ruff.lint]
+select = [
+    "E",  # pycodestyle errors
+    "W",  # pycodestyle warnings
+    "F",  # pyflakes
+    "I",  # isort
+    "C",  # flake8-comprehensions
+    "B",  # flake8-bugbear
+    "UP",  # pyupgrade
+]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,3 +23,8 @@ python_requires = >=3.7
 [options.entry_points]
 console_scripts =
     cbrain = cbrain_cli.main:main
+
+[options.extras_require]
+dev =
+    pre-commit>=3.5.0
+    ruff>=0.8.5

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,11 @@
-from setuptools import setup
+from setuptools import find_packages, setup
 
-setup()
+setup(
+    packages=find_packages(),
+    extras_require={
+        "dev": [
+            "pre-commit>=3.5.0",
+            "ruff>=0.8.5",
+        ],
+    },
+)


### PR DESCRIPTION
- Code formatting with Ruff
- Basic file checks (whitespace, EOF, YAML)
- Markdown link validation
- NumPyDoc style validation

## Setup
```bash
pip install -e ".[dev]" #  it installs `pre-commit` and `ruff` as defined in `setup.py`
```
Without `pre-commit install`, the hooks won't run automatically - you'd have to manually run `pre-commit run --all-files` each time.
```bash
pre-commit install 
pre-commit run --all-files
```
We can use `git commit --no-verify` to skip the pre-commit checks.

> Also Commenting out `https://github.com/numpy/numpydoc`, If it finds useful, we can work on this later. 

Fix: #9 

  