### PR TITLE
Use project_id instead of group_id in CLI arguments

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 ACElab
+Copyright (c) 2025 The Royal Institution for the Advancement of Learning / McGill University
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/cbrain_cli/data/projects.py
+++ b/cbrain_cli/data/projects.py
@@ -13,40 +13,40 @@ def switch_project(args):
     Parameters
     ----------
     args : argparse.Namespace
-        Command line arguments, including the group_id argument
+        Command line arguments, including the project_id argument
 
     Returns
     -------
     dict or None
         Dictionary containing project details if successful, None otherwise
     """
-    # Get the group ID from the group_id argument
-    group_id = getattr(args, "group_id", None)
-    if not group_id:
-        print("Error: Group ID is required")
+    # Get the project ID from the project_id argument
+    project_id = getattr(args, "project_id", None)
+    if not project_id:
+        print("Error: Project ID is required")
         return None
 
     # Handle the special case of "all"
-    if group_id == "all":
+    if project_id == "all":
         print("Project switch 'all' not yet implemented as of Aug 2025")
         return None
 
     # Convert to integer for regular group IDs
     try:
-        group_id = int(group_id)
+        group_id = int(project_id)
     except ValueError:
-        print(f"Error: Invalid group ID '{group_id}'. Must be a number or 'all'")
+        print(f"Error: Invalid project ID '{project_id}'. Must be a number or 'all'")
         return None
 
     # Step 1: Call the switch API
-    switch_endpoint = f"{cbrain_url}/groups/switch?id={group_id}"
+    switch_endpoint = f"{cbrain_url}/groups/switch?id={project_id}"
     headers = auth_headers(api_token)
 
     # Create the request
     request = urllib.request.Request(switch_endpoint, data=None, headers=headers, method="POST")
 
     with urllib.request.urlopen(request):
-        group_endpoint = f"{cbrain_url}/groups/{group_id}"
+        group_endpoint = f"{cbrain_url}/groups/{project_id}"
         group_request = urllib.request.Request(
             group_endpoint, data=None, headers=headers, method="GET"
         )
@@ -60,7 +60,7 @@ def switch_project(args):
             with open(CREDENTIALS_FILE) as f:
                 credentials = json.load(f)
 
-            credentials["current_group_id"] = group_id
+            credentials["current_project_id"] = project_id
             credentials["current_group_name"] = group_data.get("name", "Unknown")
 
             with open(CREDENTIALS_FILE, "w") as f:
@@ -108,8 +108,8 @@ def show_project(args):
         with open(CREDENTIALS_FILE) as f:
             credentials = json.load(f)
 
-        current_group_id = credentials.get("current_group_id")
-        if not current_group_id:
+        current_group_id = credentials.get("current_project_id")
+        if not current_project_id:
             return None
 
         # Get fresh group details from server
@@ -126,9 +126,9 @@ def show_project(args):
 
         except urllib.error.HTTPError as e:
             if e.code == 404:
-                print(f"Error: Current project (ID {current_group_id}) no longer exists")
+                print(f"Error: Current project (ID {current_project_id}) no longer exists")
                 # Clear the invalid group_id from credentials
-                credentials.pop("current_group_id", None)
+                credentials.pop("current_project_id", None)
                 credentials.pop("current_group_name", None)
                 with open(CREDENTIALS_FILE, "w") as f:
                     json.dump(credentials, f, indent=2)

--- a/cbrain_cli/main.py
+++ b/cbrain_cli/main.py
@@ -88,7 +88,7 @@ def main():
 
     # file list
     file_list_parser = file_subparsers.add_parser("list", help="List files")
-    file_list_parser.add_argument("--group-id", type=int, help="Filter files by group ID")
+    file_list_parser.add_argument("--project-id", type=int, help="Filter files by project ID")
     file_list_parser.add_argument("--dp-id", type=int, help="Filter files by data provider ID")
     file_list_parser.add_argument("--user-id", type=int, help="Filter files by user ID")
     file_list_parser.add_argument("--parent-id", type=int, help="Filter files by parent ID")
@@ -110,7 +110,7 @@ def main():
     file_upload_parser.add_argument(
         "--data-provider", type=int, required=True, help="Data provider ID"
     )
-    file_upload_parser.add_argument("--group-id", type=int, help="Group ID")
+    file_upload_parser.add_argument("--project-id", type=int, help="Project ID")
 
     file_upload_parser.set_defaults(func=handle_errors(handle_file_upload))
 
@@ -208,7 +208,7 @@ def main():
 
     # project switch
     project_switch_parser = project_subparsers.add_parser("switch", help="Switch to a project")
-    project_switch_parser.add_argument("group_id", help="Project/Group ID or 'all'")
+    project_switch_parser.add_argument("project_id", help="Project ID or 'all'")
     project_switch_parser.set_defaults(func=handle_errors(handle_project_switch))
 
     # project show
@@ -303,7 +303,7 @@ def main():
     tag_create_parser = tag_subparsers.add_parser("create", help="Create a new tag")
     tag_create_parser.add_argument("--name", type=str, required=True, help="Tag name")
     tag_create_parser.add_argument("--user-id", type=int, required=True, help="User ID")
-    tag_create_parser.add_argument("--group-id", type=int, required=True, help="Group ID")
+    tag_create_parser.add_argument("--project-id", type=int, required=True, help="Project ID")
     tag_create_parser.set_defaults(func=handle_errors(handle_tag_create))
 
     # tag update
@@ -315,7 +315,7 @@ def main():
     )
     tag_update_parser.add_argument("--name", type=str, required=True, help="Tag name")
     tag_update_parser.add_argument("--user-id", type=int, required=True, help="User ID")
-    tag_update_parser.add_argument("--group-id", type=int, required=True, help="Group ID")
+    tag_update_parser.add_argument("--project-id", type=int, required=True, help="Project ID")
     tag_update_parser.set_defaults(func=handle_errors(handle_tag_update))
 
     # tag delete


### PR DESCRIPTION
This PR updates CLI argument naming to match CBRAIN UI terminology.

Changes:

* Replaced `--group-id` with `--project-id` in CLI arguments.
* Updated related variable names in project handlers.
* Backend API calls still use `/groups` to remain compatible with the CBRAIN API.

This improves consistency between the CLI and the CBRAIN UI.
