### PR TITLE
Add GSoC 2025 project description to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # CBRAIN CLI
+**A Google Summer of Code (GSoC) 2025 Project**
 
 A command-line interface to a CBRAIN service
 ============================================
@@ -140,8 +141,6 @@ cbrain [options] <MODEL> <ACTION> [id_or_args]
 > </details>
 
 ## Development
-
-This is part of [**a GSoC (Google Summer of Code) 2025** project](https://summerofcode.withgoogle.com/programs/2025/projects/1An4Dp8N) sponsored by [INCF](https://www.incf.org/).
 
 The lead developer is [axif0](https://github.com/axif0), mentored by the developers of the CBRAIN project.
 


### PR DESCRIPTION
This PR addresses the final pending requirement from Issue #31. 

Upon reviewing the open issue, I noticed that the majority of the requested enhancements—including the CI test attribution to P. Rioux, the updated wording for custom setups, and the addition of CLI command examples/GIFs—were already integrated into the `README.md` in previous commits. 

This PR completes the issue by moving the **GSoC 2025** project acknowledgment to the very beginning of the README (and removing the redundant mention at the bottom), as requested by the maintainer.

### Changes Made
- [x] Added `**A Google Summer of Code (GSoC) 2025 Project**` directly under the main `# CBRAIN CLI` header.
- [x] Removed the duplicated GSoC text from the `## Development` section to keep the document clean.

**Resolves:** #31