### PR TITLE
[codex] Add pytest to dev tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,12 @@ pip install -e ".[dev]"
 
 This project is a pure Python CLI. There is no separate compile or build step for normal development; installing in editable mode is enough to run the local `cbrain` command.
 
+The `dev` extra installs the local review tools used by this repository:
+
+- `ruff` for linting and formatting;
+- `pytest` for focused unit tests;
+- `pre-commit` for local hook checks.
+
 ### Linting And Formatting
 
 Ruff is used for linting and formatting:
@@ -204,6 +210,12 @@ pre-commit run --all-files
 The existing test suite is based on capture tests in `capture_tests/`. These are shell-based CLI output regression tests: they run commands from `capture_tests/cbrain_cli_commands` and compare the captured terminal output against `capture_tests/expected_captures.txt`.
 
 Capture tests require a local CBRAIN test server on `localhost:3000` with the expected test database seed. The GitHub Actions workflow sets this up by checking out the CBRAIN server repository at https://github.com/aces/cbrain.
+
+Focused unit tests should use `pytest` and should not require a live CBRAIN server:
+
+```bash
+pytest
+```
 
 When command output intentionally changes, update `capture_tests/expected_captures.txt`. When behavior changes without intended output changes, prefer adding focused unit tests where possible.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,4 +27,5 @@ console_scripts =
 [options.extras_require]
 dev =
     pre-commit>=3.5.0
+    pytest>=8.0.0
     ruff>=0.8.5

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ setup(
     extras_require={
         "dev": [
             "pre-commit>=3.5.0",
+            "pytest>=8.0.0",
             "ruff>=0.8.5",
         ],
     },


### PR DESCRIPTION
## Summary

- add `pytest` to the development extra in both packaging metadata files
- document the tools installed by `.[dev]`
- document the intended `pytest` command for focused unit tests

## Why

The README already tells contributors to install `.[dev]`, and the project plan calls for pytest-based unit tests. The local development extra should install the tools reviewers are expected to run.

## Validation

- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/python -m pytest` runs, but currently exits with code 5 because no pytest tests exist yet
