### PR TITLE
Implement `Phase 1` items and `Phase 2` task 8 from `plan.md`

### DIFF
--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -1,0 +1,21 @@
+name: pre-commit
+
+on: [push, pull_request]
+
+jobs:
+  pre-commit:
+    name: Pre-commit checks
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run pre-commit
+        run: |
+          pip install pre-commit
+          pre-commit run --config .pre-commit-config.yaml --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
         exclude: ^capture_tests/expected_captures\.txt$
@@ -9,13 +9,13 @@ repos:
       - id: check-yaml
 
   - repo: https://github.com/tcort/markdown-link-check
-    rev: v3.13.6
+    rev: v3.14.2
     hooks:
       - id: markdown-link-check
         args: [-q]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.5
+    rev: v0.15.18
     hooks:
       - id: ruff
         args: [--fix]

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ When prompted for "Enter CBRAIN server URL prefix", enter:
 ## API Reference
 
 This CLI interfaces with the CBRAIN REST API. For complete API documentation and specifications, refer to:
-- [CBRAIN API Documentation (Swagger)](https://app.swaggerhub.com/apis/prioux/CBRAIN/7.0.0)
+- [CBRAIN API Documentation (Swagger)](https://portal.cbrain.mcgill.ca/swagger)
 
 ## CLI Usage
 
@@ -197,7 +197,7 @@ The hooks currently:
 - run `ruff --fix`;
 - run `ruff format`.
 
-The generated capture fixture `capture_tests/expected_captures.txt` is excluded from whitespace and Ruff hooks because exact captured output is intentional there.
+The generated capture fixture `capture_tests/expected_captures.txt` is excluded from whitespace hooks and from Ruff (via `pyproject.toml`) because exact captured output is intentional there.
 
 To run the hooks manually:
 

--- a/capture_tests/cbrain_cli_commands
+++ b/capture_tests/cbrain_cli_commands
@@ -70,13 +70,14 @@ cbrain         project show 10
 cbrain --json  project show 10
 cbrain --jsonl project show 10
 
-cbrain         project unswitch
-cbrain --json  project unswitch
-cbrain --jsonl project unswitch
-
 cbrain         project switch 10
+cbrain         project unswitch
+
 cbrain --json  project switch 10
+cbrain --json  project unswitch
+
 cbrain --jsonl project switch 10
+cbrain --jsonl project unswitch
 
 cbrain         project switch all  # 'all' not yet implemented as of Aug 2025
 cbrain --json  project switch all

--- a/capture_tests/cbrain_cli_commands
+++ b/capture_tests/cbrain_cli_commands
@@ -70,6 +70,10 @@ cbrain         project show 10
 cbrain --json  project show 10
 cbrain --jsonl project show 10
 
+cbrain         project unswitch
+cbrain --json  project unswitch
+cbrain --jsonl project unswitch
+
 cbrain         project switch 10
 cbrain --json  project switch 10
 cbrain --jsonl project switch 10
@@ -167,4 +171,3 @@ cbrain         file move --file-id 2 --dp-id 15
 
 # Logging out
 cbrain         logout
-

--- a/capture_tests/expected_captures.txt
+++ b/capture_tests/expected_captures.txt
@@ -489,22 +489,29 @@ Stderr:
 ############################
 Command: cbrain --json  project switch 10
 Status: 0
-Stdout: 37 bytes
+Stdout: 125 bytes
 Stderr: 0 bytes
 
 Stdout:
-Current project is "NormTest1" ID=10
+{
+  "id": 10,
+  "name": "NormTest1",
+  "description": null,
+  "type": "WorkGroup",
+  "site_id": null,
+  "invisible": false
+}
 Stderr:
 (No output)
 
 ############################
 Command: cbrain --jsonl project switch 10
 Status: 0
-Stdout: 37 bytes
+Stdout: 100 bytes
 Stderr: 0 bytes
 
 Stdout:
-Current project is "NormTest1" ID=10
+{"id":10,"name":"NormTest1","description":null,"type":"WorkGroup","site_id":null,"invisible":false}
 Stderr:
 (No output)
 

--- a/capture_tests/expected_captures.txt
+++ b/capture_tests/expected_captures.txt
@@ -476,44 +476,6 @@ Stderr:
 (No output)
 
 ############################
-Command: cbrain         project unswitch
-Status: 0
-Stdout: 75 bytes
-Stderr: 0 bytes
-
-Stdout:
-No current project set. Use 'cbrain project switch <ID>' to set a project.
-Stderr:
-(No output)
-
-############################
-Command: cbrain --json  project unswitch
-Status: 0
-Stdout: 121 bytes
-Stderr: 0 bytes
-
-Stdout:
-{
-  "previous_group_id": null,
-  "previous_group_name": null,
-  "current_group_id": null,
-  "current_group_name": null
-}
-Stderr:
-(No output)
-
-############################
-Command: cbrain --jsonl project unswitch
-Status: 0
-Stdout: 104 bytes
-Stderr: 0 bytes
-
-Stdout:
-{"previous_group_id":null,"previous_group_name":null,"current_group_id":null,"current_group_name":null}
-Stderr:
-(No output)
-
-############################
 Command: cbrain         project switch 10
 Status: 0
 Stdout: 37 bytes
@@ -521,6 +483,17 @@ Stderr: 0 bytes
 
 Stdout:
 Current project is "NormTest1" ID=10
+Stderr:
+(No output)
+
+############################
+Command: cbrain         project unswitch
+Status: 0
+Stdout: 75 bytes
+Stderr: 0 bytes
+
+Stdout:
+No current project set. Use 'cbrain project switch <ID>' to set a project.
 Stderr:
 (No output)
 
@@ -543,6 +516,22 @@ Stderr:
 (No output)
 
 ############################
+Command: cbrain --json  project unswitch
+Status: 0
+Stdout: 121 bytes
+Stderr: 0 bytes
+
+Stdout:
+{
+  "previous_group_id": null,
+  "previous_group_name": null,
+  "current_group_id": null,
+  "current_group_name": null
+}
+Stderr:
+(No output)
+
+############################
 Command: cbrain --jsonl project switch 10
 Status: 0
 Stdout: 100 bytes
@@ -550,6 +539,17 @@ Stderr: 0 bytes
 
 Stdout:
 {"id":10,"name":"NormTest1","description":null,"type":"WorkGroup","site_id":null,"invisible":false}
+Stderr:
+(No output)
+
+############################
+Command: cbrain --jsonl project unswitch
+Status: 0
+Stdout: 104 bytes
+Stderr: 0 bytes
+
+Stdout:
+{"previous_group_id":null,"previous_group_name":null,"current_group_id":null,"current_group_name":null}
 Stderr:
 (No output)
 

--- a/capture_tests/expected_captures.txt
+++ b/capture_tests/expected_captures.txt
@@ -489,11 +489,11 @@ Stderr:
 ############################
 Command: cbrain         project unswitch
 Status: 0
-Stdout: 75 bytes
+Stdout: 42 bytes
 Stderr: 0 bytes
 
 Stdout:
-No current project set. Use 'cbrain project switch <ID>' to set a project.
+Cleared current project "NormTest1" ID=10
 Stderr:
 (No output)
 
@@ -518,13 +518,13 @@ Stderr:
 ############################
 Command: cbrain --json  project unswitch
 Status: 0
-Stdout: 121 bytes
+Stdout: 126 bytes
 Stderr: 0 bytes
 
 Stdout:
 {
-  "previous_group_id": null,
-  "previous_group_name": null,
+  "previous_group_id": 10,
+  "previous_group_name": "NormTest1",
   "current_group_id": null,
   "current_group_name": null
 }
@@ -545,11 +545,11 @@ Stderr:
 ############################
 Command: cbrain --jsonl project unswitch
 Status: 0
-Stdout: 104 bytes
+Stdout: 109 bytes
 Stderr: 0 bytes
 
 Stdout:
-{"previous_group_id":null,"previous_group_name":null,"current_group_id":null,"current_group_name":null}
+{"previous_group_id":10,"previous_group_name":"NormTest1","current_group_id":null,"current_group_name":null}
 Stderr:
 (No output)
 

--- a/capture_tests/expected_captures.txt
+++ b/capture_tests/expected_captures.txt
@@ -476,6 +476,44 @@ Stderr:
 (No output)
 
 ############################
+Command: cbrain         project unswitch
+Status: 0
+Stdout: 75 bytes
+Stderr: 0 bytes
+
+Stdout:
+No current project set. Use 'cbrain project switch <ID>' to set a project.
+Stderr:
+(No output)
+
+############################
+Command: cbrain --json  project unswitch
+Status: 0
+Stdout: 121 bytes
+Stderr: 0 bytes
+
+Stdout:
+{
+  "previous_group_id": null,
+  "previous_group_name": null,
+  "current_group_id": null,
+  "current_group_name": null
+}
+Stderr:
+(No output)
+
+############################
+Command: cbrain --jsonl project unswitch
+Status: 0
+Stdout: 104 bytes
+Stderr: 0 bytes
+
+Stdout:
+{"previous_group_id":null,"previous_group_name":null,"current_group_id":null,"current_group_name":null}
+Stderr:
+(No output)
+
+############################
 Command: cbrain         project switch 10
 Status: 0
 Stdout: 37 bytes

--- a/cbrain_cli/cli_utils.py
+++ b/cbrain_cli/cli_utils.py
@@ -6,23 +6,22 @@ import urllib.parse
 import urllib.request
 
 # import importlib.metadata
-from cbrain_cli.config import CREDENTIALS_FILE, DEFAULT_HEADERS, auth_headers
+from cbrain_cli.config import DEFAULT_HEADERS, auth_headers, load_credentials
 
-try:
-    # MARK: Credentials.
-    with open(CREDENTIALS_FILE) as f:
-        credentials = json.load(f)
+credentials = load_credentials() or {}
+cbrain_url = credentials.get("cbrain_url")
+api_token = credentials.get("api_token")
+user_id = credentials.get("user_id")
+cbrain_timestamp = credentials.get("timestamp")
 
-    # Get credentials.
-    cbrain_url = credentials.get("cbrain_url")
-    api_token = credentials.get("api_token")
-    user_id = credentials.get("user_id")
-    cbrain_timestamp = credentials.get("timestamp")
-except FileNotFoundError:
-    cbrain_url = None
-    api_token = None
-    user_id = None
-    cbrain_timestamp = None
+PAGINATABLE_ACTIONS = {
+    ("file", "list"),
+    ("dataprovider", "list"),
+    ("tool", "list"),
+    ("tool-config", "list"),
+    ("tag", "list"),
+    ("task", "list"),
+}
 
 
 class CliValidationError(Exception):

--- a/cbrain_cli/config.py
+++ b/cbrain_cli/config.py
@@ -2,6 +2,7 @@
 CBRAIN CLI Configuration
 """
 
+import json
 from pathlib import Path
 
 # Default settings.
@@ -10,7 +11,6 @@ DEFAULT_BASE_URL = "http://localhost:3000"
 # Session file configuration.
 SESSION_FILE_DIR = Path.home() / ".config" / "cbrain"
 SESSION_FILE_NAME = "credentials.json"
-SESSION_FILE_DIR.mkdir(parents=True, exist_ok=True)
 CREDENTIALS_FILE = SESSION_FILE_DIR / SESSION_FILE_NAME
 
 # HTTP headers.
@@ -35,3 +35,23 @@ def auth_headers(api_token):
         Headers dictionary with authorization
     """
     return {"Accept": "application/json", "Authorization": f"Bearer {api_token}"}
+
+
+def load_credentials():
+    """
+    Load credentials from the session file.
+    """
+    try:
+        with open(CREDENTIALS_FILE) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+
+
+def save_credentials(credentials):
+    """
+    Save credentials to the session file.
+    """
+    CREDENTIALS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with open(CREDENTIALS_FILE, "w") as f:
+        json.dump(credentials, f, indent=2)

--- a/cbrain_cli/data/data_providers.py
+++ b/cbrain_cli/data/data_providers.py
@@ -78,7 +78,5 @@ def delete_unregistered_files(args):
     data_provider_id = getattr(args, "id", None)
     if not data_provider_id:
         raise CliValidationError("Data provider ID is required", field="id")
-    data, _ = api_send(
-        f"{cbrain_url}/data_providers/{data_provider_id}/delete", api_token
-    )
+    data, _ = api_send(f"{cbrain_url}/data_providers/{data_provider_id}/delete", api_token)
     return data

--- a/cbrain_cli/data/files.py
+++ b/cbrain_cli/data/files.py
@@ -105,9 +105,7 @@ def _change_provider(args, operation):
     if not file_ids:
         raise CliValidationError("File ID(s) are required", field="--file-id")
     if not dest_provider_id:
-        raise CliValidationError(
-            "Destination data provider ID is required", field="--dp-id"
-        )
+        raise CliValidationError("Destination data provider ID is required", field="--dp-id")
     payload = {
         "file_ids": file_ids,
         "data_provider_id_for_mv_cp": dest_provider_id,

--- a/cbrain_cli/data/projects.py
+++ b/cbrain_cli/data/projects.py
@@ -1,4 +1,3 @@
-import json
 import urllib.error
 
 from cbrain_cli.cli_utils import (
@@ -9,7 +8,7 @@ from cbrain_cli.cli_utils import (
     api_token,
     cbrain_url,
 )
-from cbrain_cli.config import CREDENTIALS_FILE
+from cbrain_cli.config import load_credentials, save_credentials
 
 
 def switch_project(args):
@@ -46,17 +45,50 @@ def switch_project(args):
     api_send(f"{cbrain_url}/groups/switch?id={group_id}", api_token)
     group_data = api_get(f"{cbrain_url}/groups/{group_id}", api_token)
 
-    if CREDENTIALS_FILE.exists():
-        with open(CREDENTIALS_FILE) as f:
-            credentials = json.load(f)
-
+    credentials = load_credentials()
+    if credentials is not None:
         credentials["current_group_id"] = group_id
         credentials["current_group_name"] = group_data.get("name", "Unknown")
-
-        with open(CREDENTIALS_FILE, "w") as f:
-            json.dump(credentials, f, indent=2)
+        save_credentials(credentials)
 
     return group_data
+
+
+def unswitch_project(args):
+    """
+    Clear the current project/group on the server and in local credentials.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Command line arguments
+
+    Returns
+    -------
+    dict
+        Previous and current group identifiers (all None when no project was set)
+    """
+    credentials = load_credentials()
+    previous_group_id = None
+    previous_group_name = None
+
+    if credentials is not None:
+        previous_group_id = credentials.get("current_group_id")
+        previous_group_name = credentials.get("current_group_name")
+
+    api_send(f"{cbrain_url}/groups/switch", api_token)
+
+    if credentials is not None:
+        credentials.pop("current_group_id", None)
+        credentials.pop("current_group_name", None)
+        save_credentials(credentials)
+
+    return {
+        "previous_group_id": previous_group_id,
+        "previous_group_name": previous_group_name,
+        "current_group_id": None,
+        "current_group_name": None,
+    }
 
 
 def show_project(args):
@@ -77,7 +109,7 @@ def show_project(args):
     project_id = getattr(args, "project_id", None)
 
     if project_id:
-    # Show specific project by ID
+        # Show specific project by ID
         try:
             return api_get(f"{cbrain_url}/groups/{project_id}", api_token)
         except urllib.error.HTTPError as e:
@@ -85,8 +117,9 @@ def show_project(args):
                 raise CliApiError(f"Project with ID {project_id} not found")
             raise
 
-    with open(CREDENTIALS_FILE) as f:
-        credentials = json.load(f)
+    credentials = load_credentials()
+    if credentials is None:
+        return None
 
     current_group_id = credentials.get("current_group_id")
     if not current_group_id:
@@ -98,11 +131,8 @@ def show_project(args):
         if e.code == 404:
             credentials.pop("current_group_id", None)
             credentials.pop("current_group_name", None)
-            with open(CREDENTIALS_FILE, "w") as f:
-                json.dump(credentials, f, indent=2)
-            raise CliApiError(
-                f"Current project (ID {current_group_id}) no longer exists"
-            )
+            save_credentials(credentials)
+            raise CliApiError(f"Current project (ID {current_group_id}) no longer exists")
         raise
 
 

--- a/cbrain_cli/data/projects.py
+++ b/cbrain_cli/data/projects.py
@@ -40,7 +40,7 @@ def switch_project(args):
     except ValueError:
         raise CliValidationError(
             f"Invalid group ID '{group_id}'. Must be a number or 'all'", field="group_id"
-        )
+        ) from None
 
     api_send(f"{cbrain_url}/groups/switch?id={group_id}", api_token)
     group_data = api_get(f"{cbrain_url}/groups/{group_id}", api_token)
@@ -76,7 +76,8 @@ def unswitch_project(args):
         previous_group_id = credentials.get("current_group_id")
         previous_group_name = credentials.get("current_group_name")
 
-    api_send(f"{cbrain_url}/groups/switch", api_token)
+    if previous_group_id:
+        api_send(f"{cbrain_url}/groups/switch", api_token)
 
     if credentials is not None:
         credentials.pop("current_group_id", None)
@@ -114,7 +115,7 @@ def show_project(args):
             return api_get(f"{cbrain_url}/groups/{project_id}", api_token)
         except urllib.error.HTTPError as e:
             if e.code == 404:
-                raise CliApiError(f"Project with ID {project_id} not found")
+                raise CliApiError(f"Project with ID {project_id} not found") from None
             raise
 
     credentials = load_credentials()
@@ -132,7 +133,7 @@ def show_project(args):
             credentials.pop("current_group_id", None)
             credentials.pop("current_group_name", None)
             save_credentials(credentials)
-            raise CliApiError(f"Current project (ID {current_group_id}) no longer exists")
+            raise CliApiError(f"Current project (ID {current_group_id}) no longer exists") from None
         raise
 
 

--- a/cbrain_cli/data/tags.py
+++ b/cbrain_cli/data/tags.py
@@ -100,9 +100,7 @@ def update_tag(args):
     if not tag_id:
         raise CliValidationError("Tag ID is required", field="tag_id")
     payload = _tag_payload(args)
-    data, status = api_send(
-        f"{cbrain_url}/tags/{tag_id}", api_token, method="PUT", payload=payload
-    )
+    data, status = api_send(f"{cbrain_url}/tags/{tag_id}", api_token, method="PUT", payload=payload)
     success = status in (200, 201, 204)
     return data, success, None, status
 

--- a/cbrain_cli/data/tool_configs.py
+++ b/cbrain_cli/data/tool_configs.py
@@ -48,6 +48,4 @@ def tool_config_boutiques_descriptor(args):
     config_id = getattr(args, "id", None)
     if not config_id:
         raise CliValidationError("Tool configuration ID is required", field="id")
-    return api_get(
-        f"{cbrain_url}/tool_configs/{config_id}/boutiques_descriptor", api_token
-    )
+    return api_get(f"{cbrain_url}/tool_configs/{config_id}/boutiques_descriptor", api_token)

--- a/cbrain_cli/data/tools.py
+++ b/cbrain_cli/data/tools.py
@@ -1,6 +1,5 @@
 from cbrain_cli.cli_utils import (
     CliApiError,
-    CliResponseError,
     CliValidationError,
     api_get,
     api_token,
@@ -11,35 +10,38 @@ from cbrain_cli.cli_utils import (
 
 def list_tools(args):
     """
-    Get tool details or list of all tools.
-
-    Parameters
-    ----------
-    args : argparse.Namespace
-        Command line arguments, including the tool argument with tool_id if specified
-
-    Returns
-    -------
-    dict or list or None
-        - dict: when tool_id is provided and found
-        - list: when no tool_id is provided
-        - None: when error occurs or tool not found
+    Get paginated list of tools from CBRAIN.
     """
-    # Get the tool ID from the id argument if provided.
-    tool_id = getattr(args, "id", None)
-    if tool_id is None and getattr(args, "action", None) == "show":
-        raise CliValidationError("Tool ID is required", field="id")
     params = pagination(args, {})
-    tools_data = api_get(f"{cbrain_url}/tools", api_token, params)
+    return api_get(f"{cbrain_url}/tools", api_token, params)
 
-    if not isinstance(tools_data, list):
-        raise CliResponseError("Unexpected response format from server")
 
-    if tool_id:
-        # Filter for a specific tool
-        tool = next((t for t in tools_data if t.get("id") == tool_id), None)
-        if not tool:
-            raise CliApiError(f"Tool with ID {tool_id} not found")
-        return tool
+def show_tool(args):
+    """
+    Get detailed information about a specific tool from CBRAIN.
 
-    return tools_data
+    Searches paginated ``GET /tools`` results because ``GET /tools/{id}``
+    returns 204 No Content on this API.
+    """
+    tool_id = getattr(args, "id", None)
+    if not tool_id:
+        raise CliValidationError("Tool ID is required", field="id")
+
+    per_page = 20
+    page = 1
+    while True:
+        tools_page = api_get(
+            f"{cbrain_url}/tools",
+            api_token,
+            {"page": str(page), "per_page": str(per_page)},
+        )
+        if not tools_page:
+            break
+        for tool in tools_page:
+            if tool.get("id") == tool_id:
+                return tool
+        if len(tools_page) < per_page:
+            break
+        page += 1
+
+    raise CliApiError(f"Tool with ID {tool_id} not found")

--- a/cbrain_cli/formatter/data_providers_fmt.py
+++ b/cbrain_cli/formatter/data_providers_fmt.py
@@ -1,4 +1,4 @@
-from cbrain_cli.cli_utils import dynamic_table_print, display_key_value_table, output_json
+from cbrain_cli.cli_utils import display_key_value_table, dynamic_table_print, output_json
 
 
 def print_provider_details(provider_data, args):

--- a/cbrain_cli/formatter/files_fmt.py
+++ b/cbrain_cli/formatter/files_fmt.py
@@ -50,6 +50,10 @@ def print_files_list(files_data, args):
     if output_json(args, files_data):
         return
 
+    if not files_data:
+        print("No files found.")
+        return
+
     # Use the reusable dynamic table formatter
     dynamic_table_print(files_data, ["id", "type", "name"], ["ID", "Type", "File Name"])
 

--- a/cbrain_cli/formatter/projects_fmt.py
+++ b/cbrain_cli/formatter/projects_fmt.py
@@ -22,10 +22,14 @@ def print_projects_list(projects_data, args):
     if output_json(args, formatted_data):
         return
 
+    if not formatted_data:
+        print("No projects found.")
+        return
+
     dynamic_table_print(formatted_data, ["id", "type", "name"], ["ID", "Type", "Project Name"])
 
 
-def print_current_project(project_data):
+def print_current_project(project_data, args=None):
     """
     Print current project details.
 
@@ -33,7 +37,12 @@ def print_current_project(project_data):
     ----------
     project_data : dict
         Dictionary containing project name and ID
+    args : argparse.Namespace, optional
+        Command line arguments, including the --json flag
     """
+    if args is not None and output_json(args, project_data):
+        return
+
     group_name = project_data.get("name", "Unknown")
     group_id = project_data.get("id")
     print(f'Current project is "{group_name}" ID={group_id}')
@@ -73,8 +82,39 @@ def print_project_details(project_data, args):
             print(line)
 
 
-def print_no_project():
+def print_no_project(args=None):
     """
     Print message when no current project is set.
+
+    Parameters
+    ----------
+    args : argparse.Namespace, optional
+        Command line arguments, including the --json flag
     """
+    result = {"current_group_id": None, "current_group_name": None}
+    if args is not None and output_json(args, result):
+        return
+
     print("No current project set. Use 'cbrain project switch <ID>' to set a project.")
+
+
+def print_unswitch_result(result, args):
+    """
+    Print the result of clearing the current project context.
+
+    Parameters
+    ----------
+    result : dict
+        Unswitch result with previous and current group identifiers
+    args : argparse.Namespace
+        Command line arguments, including the --json flag
+    """
+    if output_json(args, result):
+        return
+
+    previous_group_id = result.get("previous_group_id")
+    if previous_group_id:
+        previous_group_name = result.get("previous_group_name", "Unknown")
+        print(f'Cleared current project "{previous_group_name}" ID={previous_group_id}')
+    else:
+        print("No current project set. Use 'cbrain project switch <ID>' to set a project.")

--- a/cbrain_cli/handlers.py
+++ b/cbrain_cli/handlers.py
@@ -136,13 +136,13 @@ def handle_project_switch(args):
     result = projects.switch_project(args)
     if result is None:
         return 1
-    projects_fmt.print_current_project(result)
+    projects_fmt.print_current_project(result, args)
 
 
 def handle_project_show(args):
     """Display information about the currently active project or a specific project by ID."""
     result = projects.show_project(args)
-    if result:
+    if result is not None:
         # Check if a specific project ID was requested
         project_id = getattr(args, "project_id", None)
         if project_id:
@@ -150,23 +150,24 @@ def handle_project_show(args):
             projects_fmt.print_project_details(result, args)
         else:
             # Show current project information
-            projects_fmt.print_current_project(result)
+            projects_fmt.print_current_project(result, args)
     else:
         # Only show "no project" message if no specific ID was requested
         project_id = getattr(args, "project_id", None)
         if not project_id:
-            projects_fmt.print_no_project()
+            projects_fmt.print_no_project(args)
 
 
 def handle_project_unswitch(args):
     """Unswitch from current project context."""
-    print("Project Unswitch 'all' not yet implemented as of Aug 2025")
+    result = projects.unswitch_project(args)
+    projects_fmt.print_unswitch_result(result, args)
 
 
 # Tool command handlers
 def handle_tool_show(args):
     """Retrieve and display detailed information about a specific computational tool."""
-    result = tools.list_tools(args)
+    result = tools.show_tool(args)
     if result is None:
         return 1
     tools_fmt.print_tool_details(result, args)

--- a/cbrain_cli/main.py
+++ b/cbrain_cli/main.py
@@ -5,7 +5,14 @@ Setup and commands for the CBRAIN CLI command line interface.
 import argparse
 import sys
 
-from cbrain_cli.cli_utils import handle_errors, is_authenticated, version_info
+from cbrain_cli.cli_utils import (
+    PAGINATABLE_ACTIONS,
+    CliValidationError,
+    handle_errors,
+    is_authenticated,
+    pagination,
+    version_info,
+)
 from cbrain_cli.data.tasks import operation_task
 from cbrain_cli.handlers import (
     handle_background_list,
@@ -235,7 +242,7 @@ def main():
     tool_show_parser.add_argument("id", type=int, help="Tool ID")
     tool_show_parser.set_defaults(func=handle_errors(handle_tool_show))
 
-    # tool list (reusing show_tool without id)
+    # tool list
     tool_list_parser = tool_subparsers.add_parser("list", help="List all tools")
     tool_list_parser.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     tool_list_parser.add_argument(
@@ -404,9 +411,18 @@ def main():
         parser.print_help()
         return
 
-    # Handle session commands (no authentication needed for login, version, and whoami).
+    if (args.command, getattr(args, "action", None)) in PAGINATABLE_ACTIONS:
+        try:
+            pagination(args, {})
+        except CliValidationError as e:
+            print(f"Error: {e}")
+            return 1
+
+    # Handle session commands (no authentication needed for login, logout, version, and whoami).
     if args.command == "login":
         return handle_errors(create_session)(args)
+    elif args.command == "logout":
+        return handle_errors(logout_session)(args)
     elif args.command == "version":
         return handle_errors(version_info)(args)
     elif args.command == "whoami":
@@ -417,9 +433,7 @@ def main():
         return 1
 
     # Handle authenticated commands.
-    if args.command == "logout":
-        return handle_errors(logout_session)(args)
-    elif args.command in [
+    if args.command in [
         "file",
         "dataprovider",
         "project",

--- a/cbrain_cli/sessions.py
+++ b/cbrain_cli/sessions.py
@@ -1,6 +1,5 @@
 import datetime
 import getpass
-import json
 import urllib.error
 
 from cbrain_cli.cli_utils import (
@@ -10,7 +9,7 @@ from cbrain_cli.cli_utils import (
     api_token,
     cbrain_url,
 )
-from cbrain_cli.config import CREDENTIALS_FILE, DEFAULT_BASE_URL
+from cbrain_cli.config import CREDENTIALS_FILE, DEFAULT_BASE_URL, load_credentials, save_credentials
 
 
 # MARK: Create Session.
@@ -41,7 +40,9 @@ def create_session(args):
     if not password:
         raise CliValidationError("Password is required", field="password")
 
-    response_data = api_post_form(f"{cbrain_url}/session", {"login": username, "password": password})
+    response_data = api_post_form(
+        f"{cbrain_url}/session", {"login": username, "password": password}
+    )
 
     cbrain_api_token = response_data.get("cbrain_api_token")
     cbrain_user_id = response_data.get("user_id")
@@ -57,8 +58,7 @@ def create_session(args):
         "timestamp": datetime.datetime.now().isoformat(),
     }
 
-    with open(CREDENTIALS_FILE, "w") as f:
-        json.dump(credentials, f, indent=2)
+    save_credentials(credentials)
 
     print(f"Connection successful, API token saved in {CREDENTIALS_FILE}")
     return 0
@@ -75,9 +75,21 @@ def logout_session(args):
         A command is run via inputs from the user.
     """
 
+    if not CREDENTIALS_FILE.exists():
+        print("Not logged in. Use 'cbrain login' to login first.")
+        return 0
+
+    credentials = load_credentials()
+    if credentials is None:
+        print("Invalid credentials file. Removing local session.")
+        CREDENTIALS_FILE.unlink(missing_ok=True)
+        print(f"Local session removed from {CREDENTIALS_FILE}")
+        return 0
+
     if not cbrain_url or not api_token:
         print("Invalid credentials file. Removing local session.")
-        CREDENTIALS_FILE.unlink()
+        CREDENTIALS_FILE.unlink(missing_ok=True)
+        print(f"Local session removed from {CREDENTIALS_FILE}")
         return 0
 
     try:
@@ -94,7 +106,7 @@ def logout_session(args):
     except urllib.error.URLError as e:
         print(f"Network error during logout: {e}")
 
-    # Always remove local credentials file.
-    CREDENTIALS_FILE.unlink()
-    print(f"Local session removed from {CREDENTIALS_FILE}")
+    if CREDENTIALS_FILE.exists():
+        CREDENTIALS_FILE.unlink()
+        print(f"Local session removed from {CREDENTIALS_FILE}")
     return 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [tool.ruff]
 line-length = 100
 target-version = "py38"
+exclude = [
+    "capture_tests/expected_captures.txt",
+]
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
## Summary

This PR completes **Tasks 2–7** of **Phase 1** and **Task 8** of **Phase 2** as outlined in `plan.md`.

## Task Coverages from[ `Plan.md`](https://github.com/aces/cbrain-cli/blob/8fb08335cf9b97dedb385320a89acb118119a2ae/plan.md#2-stop-execution-after-invalid-pagination)

This PR addresses the following Phase 1 & Phase 2 tasks:

* 2.Stop execution after invalid pagination
* 3.Fix tool show <id> lookup
* 4.Allow logout to clean up invalid credentials
* 5.Remove import-time config directory creation
* 6.Print empty list results consistently
* 7.Implement or remove `project unswitch`
* 8.Add CI enforcement for Ruff linting and formatting


## Steps to switch a project-
```
./cbrain project list
./cbrain project switch 14
./cbrain project show
./cbrain project unswitch
./cbrain project show
./cbrain --json project unswitch
```


I'm not sure about the project unswitch, I was reading comment on the [switch_group_helpers.rb](https://github.com/aces/cbrain/blob/6b3c7e8dbea08cf9d082f4199063034e062052f0/BrainPortal/lib/switch_group_helpers.rb#L37) code.

``` def switch_current_group(group_id)
    orig_active_group_id = cbrain_session[:active_group_id].presence

    if group_id.blank? # FIXME I am not sure what that means. Pierre May 2022
      cbrain_session[:active_group_id] = nil
      return orig_active_group_id.present?  # say if it was changed or not
    end
    