### PR TITLE
Add comprehensive test coverage & Protect credentials file permissions for cbrain_cli 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,26 +1,10 @@
-name: CI
+name: unit_tests
 
 on: [push, pull_request]
 
 jobs:
-  lint:
-    name: Pre-commit checks
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Run pre-commit
-        run: |
-          pip install pre-commit
-          pre-commit run --config .pre-commit-config.yaml --all-files
-
   test:
+    name: Pytest unit tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,30 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    name: Pre-commit checks
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run pre-commit
+        run: |
+          pip install pre-commit
+          pre-commit run --config .pre-commit-config.yaml --all-files
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.12" }
+      - run: pip install -e ".[dev]"
+      - run: python -m pytest --cov=cbrain_cli --cov-report=term-missing

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,8 @@ build/
 # Virtual Environment
 venv/
 
+# Coverage
+.coverage
+
 # macOS
 .DS_Store

--- a/cbrain_cli/config.py
+++ b/cbrain_cli/config.py
@@ -3,6 +3,7 @@ CBRAIN CLI Configuration
 """
 
 import json
+import os
 from pathlib import Path
 
 # Default settings.
@@ -12,6 +13,7 @@ DEFAULT_BASE_URL = "http://localhost:3000"
 SESSION_FILE_DIR = Path.home() / ".config" / "cbrain"
 SESSION_FILE_NAME = "credentials.json"
 CREDENTIALS_FILE = SESSION_FILE_DIR / SESSION_FILE_NAME
+DEFAULT_CREDENTIALS_MODE = 0o600
 
 # HTTP headers.
 DEFAULT_HEADERS = {
@@ -53,5 +55,35 @@ def save_credentials(credentials):
     Save credentials to the session file.
     """
     CREDENTIALS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    with open(CREDENTIALS_FILE, "w") as f:
-        json.dump(credentials, f, indent=2)
+
+    is_posix = os.name == "posix"
+
+    if is_posix:
+        # Preserve restrictive permissions when updating.
+        if CREDENTIALS_FILE.exists():
+            existing = CREDENTIALS_FILE.stat().st_mode & 0o777
+            if existing & 0o077 == 0 and existing & 0o600 == 0o600:
+                mode = existing
+            else:
+                mode = DEFAULT_CREDENTIALS_MODE
+            if not os.access(CREDENTIALS_FILE, os.W_OK):
+                os.chmod(CREDENTIALS_FILE, mode | 0o200)
+            if mode != existing:
+                os.chmod(CREDENTIALS_FILE, mode)
+        else:
+            mode = DEFAULT_CREDENTIALS_MODE
+
+        # Create with user-private permissions where supported.
+        fd = os.open(CREDENTIALS_FILE, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode)
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(credentials, f, indent=2)
+        finally:
+            try:
+                os.chmod(CREDENTIALS_FILE, mode)
+            except OSError:
+                pass
+    else:
+        # Non-POSIX: skip permission handling.
+        with open(CREDENTIALS_FILE, "w") as f:
+            json.dump(credentials, f, indent=2)

--- a/cbrain_cli/main.py
+++ b/cbrain_cli/main.py
@@ -50,14 +50,15 @@ from cbrain_cli.sessions import create_session, logout_session
 from cbrain_cli.users import whoami_user
 
 
-def main():
+def build_parser():
     """
-    The function that controls the CBRAIN CLI.
+    Build and return the CBRAIN CLI argument parser and command subparsers.
 
     Returns
     -------
-    None
-        A command is run via inputs from the user.
+    tuple
+        (parser, command_parsers) where command_parsers maps command names
+        to their top-level subparsers for help display.
     """
     parser = argparse.ArgumentParser(description="CBRAIN CLI")
     parser.add_argument("-j", "--json", action="store_true", help="Output in JSON format")
@@ -404,8 +405,36 @@ def main():
     remote_resource_show_parser.add_argument("remote_resource", type=int, help="Remote resource ID")
     remote_resource_show_parser.set_defaults(func=handle_errors(handle_remote_resource_show))
 
-    # MARK: Setup CLI
-    args = parser.parse_args()
+    command_parsers = {
+        "file": file_parser,
+        "dataprovider": dataprovider_parser,
+        "project": project_parser,
+        "tool": tool_parser,
+        "tool-config": tool_configs_parser,
+        "tag": tag_parser,
+        "background": background_parser,
+        "task": task_parser,
+        "remote-resource": remote_resource_parser,
+    }
+    return parser, command_parsers
+
+
+def main(argv=None):
+    """
+    The function that controls the CBRAIN CLI.
+
+    Parameters
+    ----------
+    argv : list of str, optional
+        Command-line arguments excluding the program name.
+
+    Returns
+    -------
+    int or None
+        Exit code when applicable.
+    """
+    parser, command_parsers = build_parser()
+    args = parser.parse_args(argv)
 
     if not args.command:
         parser.print_help()
@@ -446,24 +475,7 @@ def main():
     ]:
         if not hasattr(args, "action") or not args.action:
             # Show help for the specific model command.
-            if args.command == "file":
-                file_parser.print_help()
-            elif args.command == "dataprovider":
-                dataprovider_parser.print_help()
-            elif args.command == "project":
-                project_parser.print_help()
-            elif args.command == "tool":
-                tool_parser.print_help()
-            elif args.command == "tool-config":
-                tool_configs_parser.print_help()
-            elif args.command == "tag":
-                tag_parser.print_help()
-            elif args.command == "background":
-                background_parser.print_help()
-            elif args.command == "task":
-                task_parser.print_help()
-            elif args.command == "remote-resource":
-                remote_resource_parser.print_help()
+            command_parsers[args.command].print_help()
             return 1
         else:
             # Execute the function associated with the command.

--- a/cbrain_cli/sessions.py
+++ b/cbrain_cli/sessions.py
@@ -17,10 +17,15 @@ def create_session(args):
     """
     Create a new CBRAIN session by logging in and saving credentials.
 
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Parsed command-line arguments (unused; login is interactive).
+
     Returns
     -------
-    None
-        A command is run via inputs from the user.
+    int
+        Exit code (0 on success, 1 on failure).
     """
 
     if CREDENTIALS_FILE.exists():
@@ -69,10 +74,15 @@ def logout_session(args):
     """
     Logout from CBRAIN by deleting the session file.
 
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Parsed command-line arguments (unused).
+
     Returns
     -------
-    None
-        A command is run via inputs from the user.
+    int
+        Exit code (0 on success).
     """
 
     if not CREDENTIALS_FILE.exists():

--- a/cbrain_cli/users.py
+++ b/cbrain_cli/users.py
@@ -9,19 +9,28 @@ from cbrain_cli.cli_utils import (
     json_printer,
     user_id,
 )
-from cbrain_cli.config import CREDENTIALS_FILE, auth_headers
-
-headers = auth_headers(api_token)
+from cbrain_cli.config import auth_headers
 
 
 def user_details(user_id):
     """
-    Get user name from user ID.
+    Fetch user details from the CBRAIN API.
+
+    Parameters
+    ----------
+    user_id : int
+        CBRAIN user ID.
+
+    Returns
+    -------
+    dict or None
+        User data dictionary, or None if the request fails.
     """
-    # Get user details.
     user_endpoint = f"{cbrain_url}/users/{user_id}"
 
-    user_request = urllib.request.Request(user_endpoint, headers=headers, method="GET")
+    user_request = urllib.request.Request(
+        user_endpoint, headers=auth_headers(api_token), method="GET"
+    )
 
     try:
         with urllib.request.urlopen(user_request) as response:
@@ -39,11 +48,17 @@ def user_details(user_id):
 # MARK: Whoami
 def whoami_user(args):
     """
-    Display current user information by getting user details from server.
+    Display current user information by fetching details from the server.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Parsed command-line arguments (json, version flags).
+
     Returns
     -------
-    None
-        Prints current user information.
+    int or None
+        Exit code on credential or API failure; otherwise None after printing.
     """
     version = getattr(args, "version", False)
 
@@ -72,29 +87,16 @@ def whoami_user(args):
         return 0
 
     if version:
-        # Show masked token.
-        masked_token = (
-            api_token[:2] + "*" * (len(api_token) - 4) + api_token[-2:]
-            if len(api_token) > 4
-            else "****"
-        )
-
-        print(f"DEBUG: Found credentials {CREDENTIALS_FILE}")
-        print(f"DEBUG: User in credentials: {user_data['login']} on server {cbrain_url}")
-        print(f"DEBUG: Token found: {masked_token}")
-        print("DEBUG: Verifying token...")
-        print("DEBUG: GET /session")
-
         # Verify token by making a session request.
         session_endpoint = f"{cbrain_url}/session"
 
-        session_request = urllib.request.Request(session_endpoint, headers=headers, method="GET")
+        session_request = urllib.request.Request(
+            session_endpoint, headers=auth_headers(api_token), method="GET"
+        )
 
         try:
             with urllib.request.urlopen(session_request) as response:
                 session_data = json.loads(response.read().decode("utf-8"))
-
-                print(f"DEBUG: Got JSON reply {json.dumps(session_data)}")
 
                 # Verify local credentials match server response.
                 remote_user_id = session_data.get("user_id")
@@ -105,13 +107,6 @@ def whoami_user(args):
 
                 if remote_token != api_token:
                     print("WARNING: Token mismatch - tokens don't match")
-
-                print(f"DEBUG: GET /users/{remote_user_id}")
-                remote_user_data = user_details(remote_user_id)
-                if remote_user_data is not None:
-                    print(f"DEBUG: Got JSON reply {json.dumps(remote_user_data)}")
-                else:
-                    print("DEBUG: Failed to get user details")
 
         except (urllib.error.URLError, urllib.error.HTTPError) as e:
             handle_connection_error(e)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 [tool.ruff]
 line-length = 100
 target-version = "py38"

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,4 +28,5 @@ console_scripts =
 dev =
     pre-commit>=3.5.0
     pytest>=8.0.0
+    pytest-cov>=5.0.0
     ruff>=0.8.5

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup(
         "dev": [
             "pre-commit>=3.5.0",
             "pytest>=8.0.0",
+            "pytest-cov>=5.0.0",
             "ruff>=0.8.5",
         ],
     },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,160 @@
+import argparse
+import json
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+URL = "http://localhost:3000"
+TOKEN = "test-token"
+CREDS_FILE = "creds.json"
+
+
+def make_args(**kwargs):
+    """Build an argparse.Namespace with default page/per_page; override with kwargs."""
+    defaults = {"page": 1, "per_page": 25}
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+def patch_credentials_file(monkeypatch, path, *, sessions=False):
+    """Redirect credential file path away from the real ~/.config/cbrain."""
+    monkeypatch.setattr("cbrain_cli.config.CREDENTIALS_FILE", path)
+    if sessions:
+        monkeypatch.setattr("cbrain_cli.sessions.CREDENTIALS_FILE", path)
+
+
+def patch_module_locals(monkeypatch, *module_paths, user_id=None):
+    """Patch module-local api_token / cbrain_url (and optional user_id) copies."""
+    for module_path in module_paths:
+        monkeypatch.setattr(f"{module_path}.api_token", TOKEN)
+        monkeypatch.setattr(f"{module_path}.cbrain_url", URL)
+        if user_id is not None:
+            monkeypatch.setattr(f"{module_path}.user_id", user_id)
+
+
+def sample_credentials(**overrides):
+    """Build a credentials dict with sensible defaults for tests."""
+    credentials = {"api_token": TOKEN, "cbrain_url": URL, "user_id": 42}
+    credentials.update(overrides)
+    return credentials
+
+
+def run_main(monkeypatch, argv):
+    """Run cbrain_cli.main.main with the given argv list (including program name)."""
+    monkeypatch.setattr(sys, "argv", argv)
+    from cbrain_cli.main import main
+
+    return main(argv[1:])
+
+
+def parse_json_output(capsys):
+    """Return stdout parsed as JSON."""
+    return json.loads(capsys.readouterr().out.strip())
+
+
+@pytest.fixture
+def creds_file(tmp_path, monkeypatch):
+    """Temp credentials file patched on cbrain_cli.config."""
+    path = tmp_path / CREDS_FILE
+    patch_credentials_file(monkeypatch, path)
+    return path
+
+
+@pytest.fixture
+def sessions_creds_file(tmp_path, monkeypatch):
+    """Temp credentials file patched on config and sessions modules."""
+    path = tmp_path / CREDS_FILE
+    patch_credentials_file(monkeypatch, path, sessions=True)
+    return path
+
+
+@pytest.fixture
+def capture_urlopen(monkeypatch):
+    """Patch urlopen and capture outgoing request details.
+
+    Returns (configure, captured) where configure installs the mock and
+    captured holds url, headers, data, and method from the last request.
+    """
+
+    def configure(response_json=None, status=200, raw_body=None, side_effect=None):
+        def fake_urlopen(request):
+            captured["url"] = request.full_url
+            captured["headers"] = request.headers
+            captured["data"] = request.data
+            captured["method"] = request.method
+            mock_http_response = MagicMock()
+            if raw_body is not None:
+                body = raw_body
+            elif response_json is not None:
+                body = json.dumps(response_json).encode()
+            else:
+                body = b"{}"
+            mock_http_response.__enter__.return_value.read.return_value = body
+            mock_http_response.__enter__.return_value.status = status
+            mock_http_response.__exit__.return_value = False
+            return mock_http_response
+
+        if side_effect is not None:
+            monkeypatch.setattr("urllib.request.urlopen", MagicMock(side_effect=side_effect))
+        else:
+            monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    captured = {}
+    return configure, captured
+
+
+@pytest.fixture(autouse=True)
+def _reset_globals(monkeypatch):
+    """Reset cli_utils module-level globals before every test.
+
+    Prevents real credentials on disk from leaking into tests.
+    """
+    monkeypatch.setattr("cbrain_cli.cli_utils.api_token", None)
+    monkeypatch.setattr("cbrain_cli.cli_utils.cbrain_url", None)
+    monkeypatch.setattr("cbrain_cli.cli_utils.user_id", None)
+
+
+@pytest.fixture
+def fake_credentials(monkeypatch, _reset_globals):
+    """Set known credentials on cbrain_cli.cli_utils globals.
+
+    Explicit dependency on _reset_globals guarantees ordering — _reset_globals
+    runs first (sets None), then this fixture overwrites with real values.
+
+    Tests for data modules must ALSO patch the module-local copy, e.g.:
+        patch_module_locals(monkeypatch, "cbrain_cli.data.tasks")
+    """
+    monkeypatch.setattr("cbrain_cli.cli_utils.api_token", TOKEN)
+    monkeypatch.setattr("cbrain_cli.cli_utils.cbrain_url", URL)
+    monkeypatch.setattr("cbrain_cli.cli_utils.user_id", 1)
+
+
+@pytest.fixture
+def mock_urlopen(monkeypatch):
+    """Patch urllib.request.urlopen with a single-response MagicMock.
+
+    Returns a callable configure_mock_response(response_json, status=200) that installs the mock.
+    MagicMock chaining handles the context-manager protocol automatically.
+
+    For sequential calls (e.g. switch_project: api_send then api_get),
+    build context managers directly in the test instead:
+
+        first_http_response, second_http_response = MagicMock(), MagicMock()
+        first_http_response.__enter__.return_value.read.return_value = b'{}'
+        first_http_response.__enter__.return_value.status = 200
+        second_http_response.__enter__.return_value.read.return_value = json.dumps({...}).encode()
+        second_http_response.__enter__.return_value.status = 200
+        monkeypatch.setattr(
+            "urllib.request.urlopen",
+            MagicMock(side_effect=[first_http_response, second_http_response]),
+        )
+    """
+
+    def configure_mock_response(response_json, status=200):
+        mock_http_response = MagicMock()
+        mock_http_response.__enter__.return_value.read.return_value = json.dumps(response_json).encode()
+        mock_http_response.__enter__.return_value.status = status
+        monkeypatch.setattr("urllib.request.urlopen", MagicMock(return_value=mock_http_response))
+
+    return configure_mock_response

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,7 +153,9 @@ def mock_urlopen(monkeypatch):
 
     def configure_mock_response(response_json, status=200):
         mock_http_response = MagicMock()
-        mock_http_response.__enter__.return_value.read.return_value = json.dumps(response_json).encode()
+        mock_http_response.__enter__.return_value.read.return_value = json.dumps(
+            response_json
+        ).encode()
         mock_http_response.__enter__.return_value.status = status
         monkeypatch.setattr("urllib.request.urlopen", MagicMock(return_value=mock_http_response))
 

--- a/tests/test_background_activities.py
+++ b/tests/test_background_activities.py
@@ -1,0 +1,38 @@
+import pytest
+
+from cbrain_cli.cli_utils import CliValidationError
+from cbrain_cli.data.background_activities import (
+    list_background_activities,
+    show_background_activity,
+)
+from tests.conftest import make_args as _args
+from tests.conftest import patch_module_locals
+
+
+@pytest.fixture(autouse=True)
+def _patch_locals(monkeypatch):
+    patch_module_locals(monkeypatch, "cbrain_cli.data.background_activities")
+
+
+def test_list_background_activities_returns_list(mock_urlopen):
+    mock_urlopen([{"id": 1, "type": "CleanupJob"}])
+    result = list_background_activities(_args())
+    assert isinstance(result, list)
+    assert result[0]["id"] == 1
+
+
+def test_list_background_activities_empty_list_is_not_error(mock_urlopen):
+    """Empty list response must not raise — empty-list regression."""
+    mock_urlopen([])
+    assert list_background_activities(_args()) == []
+
+
+def test_show_background_activity_missing_id_raises():
+    with pytest.raises(CliValidationError):
+        show_background_activity(_args(id=None))
+
+
+def test_show_background_activity_returns_dict(mock_urlopen):
+    mock_urlopen({"id": 5, "type": "CleanupJob", "status": "Completed"})
+    result = show_background_activity(_args(id=5))
+    assert result["id"] == 5

--- a/tests/test_cli_utils_output.py
+++ b/tests/test_cli_utils_output.py
@@ -1,0 +1,58 @@
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from cbrain_cli.cli_utils import (
+    display_key_value_table,
+    dynamic_table_print,
+    jsonl_printer,
+    version_info,
+)
+
+
+def test_jsonl_printer_list(capsys):
+    jsonl_printer([{"a": 1}, {"b": 2}])
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0]) == {"a": 1}
+
+
+def test_jsonl_printer_dict(capsys):
+    jsonl_printer({"ok": True})
+    assert json.loads(capsys.readouterr().out.strip()) == {"ok": True}
+
+
+def test_display_key_value_table(capsys):
+    display_key_value_table([("Name", "Alpha"), ("ID", "1")])
+    out = capsys.readouterr().out
+    assert "Name" in out
+    assert "Alpha" in out
+
+
+def test_dynamic_table_print_empty(capsys):
+    dynamic_table_print([], ["id"], ["ID"])
+    assert "No data found." in capsys.readouterr().out
+
+
+def test_dynamic_table_print_with_rows(capsys):
+    dynamic_table_print(
+        [{"id": 1, "description": "short"}],
+        ["id", "description"],
+        ["ID", "Description"],
+        wrap_columns=["description"],
+        max_row_lines=2,
+    )
+    out = capsys.readouterr().out
+    assert "ID" in out
+    assert "short" in out
+
+
+def test_dynamic_table_print_header_mismatch_raises():
+    with pytest.raises(ValueError):
+        dynamic_table_print([{"id": 1}], ["id"], ["ID", "Extra"])
+
+
+def test_version_info(capsys):
+    version_info(MagicMock())
+    assert "cbrain cli client version" in capsys.readouterr().out

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,65 @@
+import json
+import os
+
+import pytest
+
+from cbrain_cli.config import auth_headers, load_credentials, save_credentials
+from tests.conftest import CREDS_FILE, patch_credentials_file, sample_credentials
+
+
+def test_auth_headers_contains_bearer_token():
+    headers = auth_headers("mytoken")
+    assert headers["Authorization"] == "Bearer mytoken"
+    assert headers["Accept"] == "application/json"
+
+
+def test_load_credentials_missing_file(creds_file):
+    assert load_credentials() is None
+
+
+def test_load_credentials_corrupt_json(creds_file):
+    creds_file.write_text("not valid json")
+    assert load_credentials() is None
+
+
+def test_save_and_load_credentials_round_trip(creds_file):
+    data = sample_credentials()
+    save_credentials(data)
+    assert load_credentials() == data
+
+
+def test_save_credentials_creates_parent_directory(tmp_path, monkeypatch):
+    nested = tmp_path / "deep" / "nested" / CREDS_FILE
+    patch_credentials_file(monkeypatch, nested)
+    save_credentials({"key": "value"})
+    assert nested.exists()
+    assert json.loads(nested.read_text()) == {"key": "value"}
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permissions")
+def test_save_credentials_private_mode(creds_file):
+    save_credentials({"key": "value"})
+    assert (creds_file.stat().st_mode & 0o777) == 0o600
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permissions")
+def test_save_credentials_tightens_loose_permissions(creds_file):
+    creds_file.write_text("{}")
+    os.chmod(creds_file, 0o644)
+    save_credentials({"key": "value"})
+    assert (creds_file.stat().st_mode & 0o777) == 0o600
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permissions")
+def test_save_credentials_preserves_restrictive_permissions(creds_file):
+    creds_file.write_text("{}")
+    os.chmod(creds_file, 0o600)
+    save_credentials({"key": "updated"})
+    assert (creds_file.stat().st_mode & 0o777) == 0o600
+    assert load_credentials() == {"key": "updated"}
+
+
+def test_save_credentials_non_posix_branch(monkeypatch, creds_file):
+    monkeypatch.setattr("os.name", "nt")
+    save_credentials({"key": "value"})
+    assert load_credentials() == {"key": "value"}

--- a/tests/test_data_api.py
+++ b/tests/test_data_api.py
@@ -1,0 +1,84 @@
+import urllib.error
+
+import pytest
+
+from cbrain_cli.cli_utils import api_get, api_post_form, api_send
+from tests.conftest import TOKEN, URL
+
+
+def test_api_get_returns_parsed_json(mock_urlopen):
+    mock_urlopen({"id": 1, "name": "tool"})
+    assert api_get(f"{URL}/tools", TOKEN) == {"id": 1, "name": "tool"}
+
+
+def test_api_get_builds_query_string(capture_urlopen):
+    """api_get appends params as a query string."""
+    configure, captured = capture_urlopen
+    configure(raw_body=b"[]")
+    api_get(f"{URL}/tools", TOKEN, {"page": "1", "per_page": "25"})
+    assert "page=1" in captured["url"]
+    assert "per_page=25" in captured["url"]
+
+
+def test_api_get_sends_authorization_header(capture_urlopen):
+    configure, captured = capture_urlopen
+    configure({})
+    api_get(f"{URL}/tools", TOKEN)
+    assert captured["headers"].get("Authorization") == f"Bearer {TOKEN}"
+
+
+def test_api_get_propagates_http_error(capture_urlopen):
+    configure, _captured = capture_urlopen
+    configure(
+        side_effect=urllib.error.HTTPError(URL, 404, "Not Found", {}, None),
+    )
+    with pytest.raises(urllib.error.HTTPError):
+        api_get(f"{URL}/tools", TOKEN)
+
+
+def test_api_post_form_returns_parsed_json(mock_urlopen):
+    mock_urlopen({"cbrain_api_token": "tok", "user_id": 2})
+    result = api_post_form(f"{URL}/session", {"login": "user", "password": "pass"})
+    assert result["cbrain_api_token"] == "tok"
+
+
+def test_api_post_form_sends_form_encoded_body(capture_urlopen):
+    configure, captured = capture_urlopen
+    configure({})
+    api_post_form(f"{URL}/session", {"login": "admin", "password": "secret"})
+    assert b"login=admin" in captured["data"]
+    assert b"password=secret" in captured["data"]
+    # no Bearer token in form post
+    assert "Bearer" not in captured["headers"].get("Authorization", "")
+
+
+def test_api_send_returns_parsed_json_and_status(mock_urlopen):
+    mock_urlopen({"id": 5}, status=201)
+    data, status = api_send(f"{URL}/tags", TOKEN, payload={"tag": {"name": "t"}})
+    assert data == {"id": 5}
+    assert status == 201
+
+
+def test_api_send_empty_body_returns_empty_dict(capture_urlopen):
+    """Empty response body must not raise JSONDecodeError."""
+    configure, _captured = capture_urlopen
+    configure(raw_body=b"")
+    data, status = api_send(f"{URL}/session", TOKEN, method="DELETE")
+    assert data == {}
+    assert status == 200
+
+
+def test_api_send_sets_content_type_for_json_payload(capture_urlopen):
+    configure, captured = capture_urlopen
+    configure({})
+    api_send(f"{URL}/tags", TOKEN, payload={"tag": {}})
+    assert captured["headers"].get("Content-type") == "application/json"
+
+
+def test_api_send_propagates_http_error(capture_urlopen):
+    configure, _captured = capture_urlopen
+    configure(
+        side_effect=urllib.error.HTTPError(URL, 500, "Error", {}, None),
+    )
+    with pytest.raises(urllib.error.HTTPError):
+        api_send(f"{URL}/tags", TOKEN)

--- a/tests/test_data_providers.py
+++ b/tests/test_data_providers.py
@@ -1,0 +1,69 @@
+import pytest
+
+from cbrain_cli.cli_utils import CliApiError, CliValidationError
+from cbrain_cli.data.data_providers import (
+    delete_unregistered_files,
+    is_alive,
+    list_data_providers,
+    show_data_provider,
+)
+from tests.conftest import make_args as _args
+from tests.conftest import patch_module_locals
+
+
+@pytest.fixture(autouse=True)
+def _patch_locals(monkeypatch):
+    patch_module_locals(monkeypatch, "cbrain_cli.data.data_providers")
+
+
+def test_list_data_providers_returns_list(mock_urlopen):
+    mock_urlopen([{"id": 1, "name": "LocalDP"}])
+    result = list_data_providers(_args())
+    assert isinstance(result, list)
+    assert result[0]["id"] == 1
+
+
+def test_list_data_providers_empty_list_is_not_error(mock_urlopen):
+    mock_urlopen([])
+    assert list_data_providers(_args()) == []
+
+
+def test_show_data_provider_with_id_returns_dict(mock_urlopen):
+    mock_urlopen({"id": 2, "name": "LocalDP"})
+    result = show_data_provider(_args(id=2))
+    assert result["id"] == 2
+
+
+def test_show_data_provider_id_none_silently_returns_list(mock_urlopen):
+    """Missing id falls back to list_data_providers — returns list, does not raise."""
+    mock_urlopen([{"id": 1}, {"id": 2}])
+    result = show_data_provider(_args(id=None))
+    assert isinstance(result, list)
+
+
+def test_show_data_provider_api_error_in_body_raises(mock_urlopen):
+    mock_urlopen({"error": "Provider unavailable"})
+    with pytest.raises(CliApiError, match="Provider unavailable"):
+        show_data_provider(_args(id=5))
+
+
+def test_is_alive_missing_id_raises():
+    with pytest.raises(CliValidationError):
+        is_alive(_args(id=None))
+
+
+def test_is_alive_returns_result(mock_urlopen):
+    mock_urlopen({"is_alive": True})
+    result = is_alive(_args(id=1))
+    assert result["is_alive"] is True
+
+
+def test_delete_unregistered_files_missing_id_raises():
+    with pytest.raises(CliValidationError):
+        delete_unregistered_files(_args(id=None))
+
+
+def test_delete_unregistered_files_returns_data(mock_urlopen):
+    mock_urlopen({"removed": 3})
+    result = delete_unregistered_files(_args(id=1))
+    assert result["removed"] == 3

--- a/tests/test_exit_codes.py
+++ b/tests/test_exit_codes.py
@@ -1,0 +1,165 @@
+import io
+import json
+from unittest.mock import MagicMock
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+from cbrain_cli.cli_utils import (
+    CliApiError,
+    CliResponseError,
+    CliValidationError,
+    get_status_code_description,
+    handle_connection_error,
+    handle_errors,
+    is_authenticated,
+)
+from tests.conftest import URL, run_main
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        HTTPError(URL, 404, "Not Found", {}, None),
+        URLError("timeout"),
+        json.JSONDecodeError("err", "", 0),
+        CliValidationError("bad input"),
+        CliApiError("api fail"),
+    ],
+)
+def test_handle_errors_returns_1_on_exception(exc):
+    assert handle_errors(MagicMock(side_effect=exc))() == 1
+
+
+def test_handle_errors_preserves_return_value():
+    assert handle_errors(MagicMock(return_value=42))() == 42
+
+
+@pytest.mark.parametrize(
+    "code,expected",
+    [
+        (401, "Authentication error (401)"),
+        (403, "Access forbidden (403)"),
+        (404, "Resource not found (404)"),
+        (500, "Server error (500)"),
+    ],
+)
+def test_handle_connection_error_http(code, expected, capsys):
+    # io.BytesIO(b"") ensures read() returns b"" reliably (fp=None triggers AttributeError)
+    handle_connection_error(HTTPError(URL, code, "Err", {}, io.BytesIO(b"")))
+    assert expected in capsys.readouterr().out
+
+
+def test_handle_connection_error_url_error_connection_refused(monkeypatch, capsys):
+    monkeypatch.setattr("cbrain_cli.cli_utils.cbrain_url", URL)
+    handle_connection_error(URLError("Connection refused"))
+    assert "Cannot connect to CBRAIN server" in capsys.readouterr().out
+
+
+def test_is_authenticated_false_when_no_credentials():
+    # _reset_globals autouse fixture leaves api_token=None
+    assert is_authenticated() is False
+
+
+def test_is_authenticated_false_when_cbrain_url_is_none(monkeypatch):
+    monkeypatch.setattr("cbrain_cli.cli_utils.api_token", "tok")
+    monkeypatch.setattr("cbrain_cli.cli_utils.user_id", 1)
+    # cbrain_url stays None from _reset_globals
+    assert is_authenticated() is False
+
+
+def test_is_authenticated_true_with_fake_credentials(fake_credentials):
+    assert is_authenticated() is True
+
+
+def test_main_file_list_unauthenticated_returns_1(monkeypatch, capsys):
+    result = run_main(monkeypatch, ["cbrain", "file", "list"])
+    assert result == 1
+    assert "Not logged in" in capsys.readouterr().out
+
+
+def test_main_version_bypasses_auth_check(monkeypatch):
+    """version command must NOT call is_authenticated."""
+    auth_checks = []
+    monkeypatch.setattr(
+        "cbrain_cli.main.is_authenticated",
+        lambda: auth_checks.append(True) or True,
+    )
+    run_main(monkeypatch, ["cbrain", "version"])
+    assert auth_checks == []
+
+
+@pytest.mark.parametrize(
+    "code,expected",
+    [
+        (422, "Validation error (422)"),
+        (418, "Client error (418)"),
+        (502, "Server error (502)"),
+        (301, "HTTP error (301)"),
+    ],
+)
+def test_get_status_code_description(code, expected):
+    assert get_status_code_description(code) == expected
+
+
+def test_handle_connection_error_401(capsys):
+    handle_connection_error(HTTPError(URL, 401, "Unauthorized", {}, io.BytesIO(b"")))
+    out = capsys.readouterr().out
+    assert "Authentication error (401)" in out
+    assert "authorized credentials" in out
+
+
+def test_handle_connection_error_json_body(capsys):
+    body = json.dumps({"message": "bad request"}).encode()
+    handle_connection_error(HTTPError(URL, 400, "Bad Request", {}, io.BytesIO(body)))
+    assert "bad request" in capsys.readouterr().out
+
+
+def test_handle_connection_error_change_password_redirect(capsys):
+    body = json.dumps({"error": "redirect change_password required"}).encode()
+    handle_connection_error(HTTPError(URL, 400, "Bad Request", {}, io.BytesIO(body)))
+    out = capsys.readouterr().out
+    assert "password change" in out
+
+
+def test_handle_connection_error_html_body(capsys):
+    body = b"<header><h1>Not Found</h1></header><h2>Record missing</h2>"
+    handle_connection_error(HTTPError(URL, 404, "Not Found", {}, io.BytesIO(body)))
+    out = capsys.readouterr().out
+    assert "Not Found" in out
+    assert "Record missing" in out
+
+
+def test_handle_connection_error_generic_url_error(capsys, monkeypatch):
+    monkeypatch.setattr("cbrain_cli.cli_utils.cbrain_url", URL)
+    handle_connection_error(URLError("timed out"))
+    assert "Connection failed" in capsys.readouterr().out
+
+
+def test_handle_connection_error_non_http_error(capsys):
+    handle_connection_error(RuntimeError("boom"))
+    assert "Connection error: boom" in capsys.readouterr().out
+
+
+def test_handle_errors_cli_response_error(capsys):
+    def boom(_args):
+        raise CliResponseError("bad response")
+
+    assert handle_errors(boom)(MagicMock()) == 1
+    assert "bad response" in capsys.readouterr().out
+
+
+def test_handle_errors_keyboard_interrupt(capsys):
+    def boom(_args):
+        raise KeyboardInterrupt
+
+    assert handle_errors(boom)(MagicMock()) == 1
+    assert "cancelled" in capsys.readouterr().out
+
+
+def test_handle_errors_unexpected_exception(capsys):
+    def boom(_args):
+        raise RuntimeError("unexpected")
+
+    assert handle_errors(boom)(MagicMock()) == 1
+    assert "unexpected" in capsys.readouterr().out

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,0 +1,130 @@
+import pytest
+
+from cbrain_cli.cli_utils import CliValidationError
+from cbrain_cli.data.files import (
+    copy_file,
+    delete_file,
+    list_files,
+    move_file,
+    show_file,
+    upload_file,
+)
+from tests.conftest import make_args as _args
+from tests.conftest import patch_module_locals
+
+
+@pytest.fixture(autouse=True)
+def _patch_locals(monkeypatch):
+    patch_module_locals(monkeypatch, "cbrain_cli.data.files")
+
+
+def test_show_file_missing_id_raises():
+    with pytest.raises(CliValidationError):
+        show_file(_args(file=None))
+
+
+def test_show_file_returns_dict(mock_urlopen):
+    mock_urlopen({"id": 10, "name": "data.csv"})
+    result = show_file(_args(file=10))
+    assert result["id"] == 10
+
+
+def test_list_files_returns_list(mock_urlopen):
+    mock_urlopen([{"id": 1, "name": "data.csv"}])
+    result = list_files(_args())
+    assert isinstance(result, list)
+
+
+def test_list_files_empty_list_is_not_error(mock_urlopen):
+    mock_urlopen([])
+    assert list_files(_args()) == []
+
+
+def test_list_files_passes_filter_params(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(req):
+        from unittest.mock import MagicMock
+        captured["url"] = req.full_url
+        cm = MagicMock()
+        cm.__enter__.return_value.read.return_value = b"[]"
+        cm.__exit__.return_value = False
+        return cm
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    list_files(_args(group_id=5, dp_id=None, user_id=None, parent_id=None, file_type=None))
+    assert "group_id=5" in captured["url"]
+
+
+def test_delete_file_missing_id_raises():
+    with pytest.raises(CliValidationError):
+        delete_file(_args(file_id=None))
+
+
+def test_delete_file_returns_data(mock_urlopen):
+    mock_urlopen({"deleted": 1})
+    result = delete_file(_args(file_id=10))
+    assert result["deleted"] == 1
+
+
+def test_upload_file_missing_path_raises(tmp_path):
+    with pytest.raises(CliValidationError, match="[Ff]ile"):
+        upload_file(_args(file_path=str(tmp_path / "nonexistent.txt"), data_provider=1, group_id=2))
+
+
+def test_upload_file_missing_group_id_raises(tmp_path):
+    f = tmp_path / "data.txt"
+    f.write_text("hello")
+    with pytest.raises(CliValidationError, match="[Gg]roup"):
+        upload_file(_args(file_path=str(f), data_provider=1, group_id=None))
+
+
+def test_copy_file_missing_file_ids_raises():
+    with pytest.raises(CliValidationError):
+        copy_file(_args(file_id=None, dp_id=1))
+
+
+def test_copy_file_missing_dp_id_raises():
+    with pytest.raises(CliValidationError):
+        copy_file(_args(file_id=[10], dp_id=None))
+
+
+def test_move_file_missing_file_ids_raises():
+    with pytest.raises(CliValidationError):
+        move_file(_args(file_id=None, dp_id=1))
+
+
+def test_copy_file_returns_tuple(mock_urlopen):
+    mock_urlopen({"moved": 1}, status=200)
+    result = copy_file(_args(file_id=[10], dp_id=2))
+    assert isinstance(result, tuple)
+
+
+def test_move_file_returns_tuple(mock_urlopen):
+    mock_urlopen({"moved": 1}, status=200)
+    result = move_file(_args(file_id=[10], dp_id=2))
+    assert isinstance(result, tuple)
+
+
+def test_upload_file_success(monkeypatch, tmp_path):
+    upload_path = tmp_path / "sample.bin"
+    upload_path.write_bytes(b"payload")
+    captured = {}
+
+    def fake_urlopen(request):
+        captured["content_type"] = request.headers.get("Content-type", "")
+        from unittest.mock import MagicMock
+
+        cm = MagicMock()
+        cm.__enter__.return_value.read.return_value = b'{"id": 99, "notice": "ok"}'
+        cm.__enter__.return_value.status = 201
+        cm.__exit__.return_value = False
+        return cm
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    result = upload_file(
+        _args(file_path=str(upload_path), data_provider=1, group_id=2),
+    )
+    assert result[0]["id"] == 99
+    assert result[2] == "sample.bin"
+    assert "multipart/form-data" in captured["content_type"]

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -45,6 +45,7 @@ def test_list_files_passes_filter_params(monkeypatch):
 
     def fake_urlopen(req):
         from unittest.mock import MagicMock
+
         captured["url"] = req.full_url
         cm = MagicMock()
         cm.__enter__.return_value.read.return_value = b"[]"

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,0 +1,277 @@
+from cbrain_cli.formatter import projects_fmt, tags_fmt, tasks_fmt
+from tests.conftest import make_args, parse_json_output
+
+
+def test_print_projects_list_empty_normal(capsys):
+    projects_fmt.print_projects_list([], make_args())
+    assert "No projects found." in capsys.readouterr().out
+
+
+def test_print_projects_list_empty_json(capsys):
+    projects_fmt.print_projects_list([], make_args(json=True))
+    assert parse_json_output(capsys) == []
+
+
+def test_print_projects_list_empty_jsonl(capsys):
+    projects_fmt.print_projects_list([], make_args(jsonl=True))
+    assert capsys.readouterr().out.strip() == ""
+
+
+def test_print_projects_list_json(capsys):
+    data = [{"id": 1, "type": "Group", "name": "Alpha"}]
+    projects_fmt.print_projects_list(data, make_args(json=True))
+    result = parse_json_output(capsys)
+    assert result[0]["name"] == "Alpha"
+
+
+def test_print_no_project_normal(capsys):
+    projects_fmt.print_no_project(make_args())
+    assert "No current project set" in capsys.readouterr().out
+
+
+def test_print_no_project_json(capsys):
+    projects_fmt.print_no_project(make_args(json=True))
+    result = parse_json_output(capsys)
+    assert result["current_group_id"] is None
+
+
+def test_print_unswitch_result_json(capsys):
+    result = {
+        "previous_group_id": 5,
+        "previous_group_name": "Alpha",
+        "current_group_id": None,
+    }
+    projects_fmt.print_unswitch_result(result, make_args(json=True))
+    parsed = parse_json_output(capsys)
+    assert parsed["previous_group_id"] == 5
+
+
+def test_print_task_data_empty_normal(capsys):
+    tasks_fmt.print_task_data([], make_args())
+    assert "No tasks found." in capsys.readouterr().out
+
+
+def test_print_task_data_empty_json(capsys):
+    tasks_fmt.print_task_data([], make_args(json=True))
+    assert parse_json_output(capsys) == []
+
+
+def test_print_task_data_json(capsys):
+    data = [{"id": 2, "type": "BoutiquesTask::X", "status": "Done"}]
+    tasks_fmt.print_task_data(data, make_args(json=True))
+    result = parse_json_output(capsys)
+    assert result[0]["id"] == 2
+
+
+def test_print_task_details_json(capsys):
+    data = {"id": 9, "type": "CbrainTask::Diagnostics", "status": "Ready"}
+    tasks_fmt.print_task_details(data, make_args(json=True))
+    result = parse_json_output(capsys)
+    assert result["status"] == "Ready"
+
+
+def test_print_tags_list_empty_normal(capsys):
+    tags_fmt.print_tags_list([], make_args())
+    assert "No tags found." in capsys.readouterr().out
+
+
+def test_print_tags_list_empty_json(capsys):
+    tags_fmt.print_tags_list([], make_args(json=True))
+    assert parse_json_output(capsys) == []
+
+
+def test_print_tags_list_json(capsys):
+    data = [{"id": 1, "name": "mytag", "user_id": 2, "group_id": 3}]
+    tags_fmt.print_tags_list(data, make_args(json=True))
+    result = parse_json_output(capsys)
+    assert result[0]["name"] == "mytag"
+
+
+def test_print_tools_list_empty_normal(capsys):
+    from cbrain_cli.formatter import tools_fmt
+
+    tools_fmt.print_tools_list([], make_args())
+    assert "No tools found." in capsys.readouterr().out
+
+
+def test_print_tools_list_with_data(capsys):
+    from cbrain_cli.formatter import tools_fmt
+
+    data = [{"id": 1, "name": "T", "category": "C", "description": "desc"}]
+    tools_fmt.print_tools_list(data, make_args())
+    assert "Found 1 tools" in capsys.readouterr().out
+
+
+def test_print_tool_details_normal(capsys):
+    from cbrain_cli.formatter import tools_fmt
+
+    tools_fmt.print_tool_details({"id": 1, "name": "T"}, make_args())
+    assert "TOOL DETAILS" in capsys.readouterr().out
+
+
+def test_print_files_list_empty(capsys):
+    from cbrain_cli.formatter import files_fmt
+
+    files_fmt.print_files_list([], make_args())
+    assert "No files found." in capsys.readouterr().out
+
+
+def test_print_file_details_with_flags(capsys):
+    from cbrain_cli.formatter import files_fmt
+
+    files_fmt.print_file_details(
+        {"id": 1, "description": "d", "hidden": True, "immutable": True, "archived": True},
+        make_args(),
+    )
+    out = capsys.readouterr().out
+    assert "description: d" in out
+    assert "hidden: True" in out
+
+
+def test_print_upload_result_success(capsys):
+    from cbrain_cli.formatter import files_fmt
+
+    files_fmt.print_upload_result({"notice": "saved"}, 201, "f.txt", 12, 3)
+    out = capsys.readouterr().out
+    assert "uploaded successfully" in out
+    assert "saved" in out
+
+
+def test_print_move_copy_result_success(capsys):
+    from cbrain_cli.formatter import files_fmt
+
+    files_fmt.print_move_copy_result({"message": "queued", "background_activity_id": 9}, 200, "copy")
+    out = capsys.readouterr().out
+    assert "queued" in out
+    assert "Background activity ID: 9" in out
+
+
+def test_print_delete_result_normal(capsys):
+    from cbrain_cli.formatter import files_fmt
+
+    files_fmt.print_delete_result({"message": "deleted"}, make_args())
+    assert "deleted" in capsys.readouterr().out
+
+
+def test_print_providers_list_empty(capsys):
+    from cbrain_cli.formatter import data_providers_fmt
+
+    data_providers_fmt.print_providers_list([], make_args())
+    assert "No data providers found." in capsys.readouterr().out
+
+
+def test_print_provider_details_normal(capsys):
+    from cbrain_cli.formatter import data_providers_fmt
+
+    data_providers_fmt.print_provider_details({"id": 1, "name": "DP", "type": "Ssh"}, make_args())
+    assert "DATA PROVIDER DETAILS" in capsys.readouterr().out
+
+
+def test_print_tool_configs_list_empty(capsys):
+    from cbrain_cli.formatter import tool_configs_fmt
+
+    tool_configs_fmt.print_tool_configs_list([], make_args())
+    assert "No tool configurations found." in capsys.readouterr().out
+
+
+def test_print_tool_config_details_normal(capsys):
+    from cbrain_cli.formatter import tool_configs_fmt
+
+    tool_configs_fmt.print_tool_config_details({"id": 1, "description": "cfg"}, make_args())
+    assert "id: 1" in capsys.readouterr().out
+
+
+def test_print_boutiques_descriptor(capsys):
+    from cbrain_cli.formatter import tool_configs_fmt
+
+    tool_configs_fmt.print_boutiques_descriptor({"name": "Tool"}, make_args())
+    assert '"name": "Tool"' in capsys.readouterr().out
+
+
+def test_print_activities_list_with_data(capsys):
+    from cbrain_cli.formatter import background_activities_fmt
+
+    data = [
+        {
+            "id": 1,
+            "user_id": 2,
+            "remote_resource_id": 3,
+            "status": "Done",
+            "created_at": "2024-01-01T12:00:00.000Z",
+            "items": [1, 2],
+            "num_successes": 2,
+            "num_failures": 0,
+        }
+    ]
+    background_activities_fmt.print_activities_list(data, make_args())
+    assert "Done" in capsys.readouterr().out
+
+
+def test_print_activity_details_normal(capsys):
+    from cbrain_cli.formatter import background_activities_fmt
+
+    background_activities_fmt.print_activity_details({"id": 1, "status": "Done"}, make_args())
+    assert "BACKGROUND ACTIVITY DETAILS" in capsys.readouterr().out
+
+
+def test_print_resources_list_with_data(capsys):
+    from cbrain_cli.formatter import remote_resources_fmt
+
+    remote_resources_fmt.print_resources_list(
+        [{"id": 1, "name": "rr", "online": True, "read_only": False}], make_args()
+    )
+    assert "REMOTE RESOURCES" in capsys.readouterr().out
+
+
+def test_print_resource_details_normal(capsys):
+    from cbrain_cli.formatter import remote_resources_fmt
+
+    remote_resources_fmt.print_resource_details({"id": 1, "name": "rr"}, make_args())
+    assert "REMOTE RESOURCE DETAILS" in capsys.readouterr().out
+
+
+def test_print_tag_details_normal(capsys):
+    tags_fmt.print_tag_details({"id": 1, "name": "t"}, make_args())
+    assert "TAG DETAILS" in capsys.readouterr().out
+
+
+def test_print_tag_operation_result_success(capsys):
+    tags_fmt.print_tag_operation_result("create", success=True)
+    assert "created successfully" in capsys.readouterr().out
+
+
+def test_print_projects_list_with_data(capsys):
+    projects_fmt.print_projects_list([{"id": 1, "type": "Group", "name": "A"}], make_args())
+    assert "Group" in capsys.readouterr().out
+
+
+def test_print_project_details_normal(capsys):
+    projects_fmt.print_project_details({"id": 1, "name": "A", "description": "line1\nline2"}, make_args())
+    out = capsys.readouterr().out
+    assert "PROJECT DETAILS" in out
+    assert "line1" in out
+
+
+def test_print_unswitch_result_normal(capsys):
+    projects_fmt.print_unswitch_result(
+        {"previous_group_id": 5, "previous_group_name": "Alpha"}, make_args()
+    )
+    assert "Cleared current project" in capsys.readouterr().out
+
+
+def test_print_task_data_normal_with_rows(capsys):
+    tasks_fmt.print_task_data(
+        [{"id": 1, "type": "BoutiquesTask::X", "status": "Done", "bourreau_id": 2, "user_id": 3, "group_id": 4}],
+        make_args(),
+    )
+    assert "Total: 1 task(s)" in capsys.readouterr().out
+
+
+def test_print_task_details_normal(capsys):
+    tasks_fmt.print_task_details(
+        {"id": 1, "type": "T", "status": "Ready", "description": "note", "params": {"k": "v"}},
+        make_args(),
+    )
+    out = capsys.readouterr().out
+    assert "Ready" in out
+    assert "PARAMETERS" in out

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -140,7 +140,9 @@ def test_print_upload_result_success(capsys):
 def test_print_move_copy_result_success(capsys):
     from cbrain_cli.formatter import files_fmt
 
-    files_fmt.print_move_copy_result({"message": "queued", "background_activity_id": 9}, 200, "copy")
+    files_fmt.print_move_copy_result(
+        {"message": "queued", "background_activity_id": 9}, 200, "copy"
+    )
     out = capsys.readouterr().out
     assert "queued" in out
     assert "Background activity ID: 9" in out
@@ -246,7 +248,9 @@ def test_print_projects_list_with_data(capsys):
 
 
 def test_print_project_details_normal(capsys):
-    projects_fmt.print_project_details({"id": 1, "name": "A", "description": "line1\nline2"}, make_args())
+    projects_fmt.print_project_details(
+        {"id": 1, "name": "A", "description": "line1\nline2"}, make_args()
+    )
     out = capsys.readouterr().out
     assert "PROJECT DETAILS" in out
     assert "line1" in out
@@ -261,7 +265,16 @@ def test_print_unswitch_result_normal(capsys):
 
 def test_print_task_data_normal_with_rows(capsys):
     tasks_fmt.print_task_data(
-        [{"id": 1, "type": "BoutiquesTask::X", "status": "Done", "bourreau_id": 2, "user_id": 3, "group_id": 4}],
+        [
+            {
+                "id": 1,
+                "type": "BoutiquesTask::X",
+                "status": "Done",
+                "bourreau_id": 2,
+                "user_id": 3,
+                "group_id": 4,
+            }
+        ],
         make_args(),
     )
     assert "Total: 1 task(s)" in capsys.readouterr().out

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,0 +1,187 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+import cbrain_cli.handlers as handlers
+from cbrain_cli.cli_utils import CliValidationError, handle_errors
+from cbrain_cli.handlers import (
+    handle_project_switch,
+    handle_project_unswitch,
+    handle_task_list,
+    handle_task_show,
+)
+from cbrain_cli.users import user_details, whoami_user
+from tests.conftest import make_args, parse_json_output, patch_module_locals
+
+LIST_HANDLER_CASES = [
+    (
+        "handle_file_list",
+        "cbrain_cli.handlers.files.list_files",
+        "cbrain_cli.handlers.files_fmt.print_files_list",
+    ),
+    (
+        "handle_dataprovider_list",
+        "cbrain_cli.handlers.data_providers.list_data_providers",
+        "cbrain_cli.handlers.data_providers_fmt.print_providers_list",
+    ),
+    (
+        "handle_project_list",
+        "cbrain_cli.handlers.projects.list_projects",
+        "cbrain_cli.handlers.projects_fmt.print_projects_list",
+    ),
+    (
+        "handle_tool_list",
+        "cbrain_cli.handlers.tools.list_tools",
+        "cbrain_cli.handlers.tools_fmt.print_tools_list",
+    ),
+    (
+        "handle_tool_config_list",
+        "cbrain_cli.handlers.tool_configs.list_tool_configs",
+        "cbrain_cli.handlers.tool_configs_fmt.print_tool_configs_list",
+    ),
+    (
+        "handle_tag_list",
+        "cbrain_cli.handlers.tags.list_tags",
+        "cbrain_cli.handlers.tags_fmt.print_tags_list",
+    ),
+    (
+        "handle_background_list",
+        "cbrain_cli.handlers.background_activities.list_background_activities",
+        "cbrain_cli.handlers.background_activities_fmt.print_activities_list",
+    ),
+    (
+        "handle_task_list",
+        "cbrain_cli.handlers.tasks.list_tasks",
+        "cbrain_cli.handlers.tasks_fmt.print_task_data",
+    ),
+    (
+        "handle_remote_resource_list",
+        "cbrain_cli.handlers.remote_resources.list_remote_resources",
+        "cbrain_cli.handlers.remote_resources_fmt.print_resources_list",
+    ),
+]
+
+
+@pytest.mark.parametrize("handler_name,list_fn,fmt_fn", LIST_HANDLER_CASES)
+def test_list_handler_empty_list_returns_none(monkeypatch, capsys, handler_name, list_fn, fmt_fn):
+    """[] is not None — formatter must be called and must not return 1."""
+    monkeypatch.setattr(list_fn, lambda _: [])
+    monkeypatch.setattr(fmt_fn, lambda result, args: print("FORMATTED"))
+    result = getattr(handlers, handler_name)(make_args())
+    assert result is None
+    assert "FORMATTED" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("handler_name,list_fn,fmt_fn", LIST_HANDLER_CASES)
+def test_list_handler_none_returns_1(monkeypatch, handler_name, list_fn, fmt_fn):
+    fmt_called = []
+    monkeypatch.setattr(list_fn, lambda _: None)
+    monkeypatch.setattr(fmt_fn, lambda *args: fmt_called.append(True))
+    assert getattr(handlers, handler_name)(make_args()) == 1
+    assert fmt_called == []
+
+
+def test_handle_task_list_returns_none_on_success(monkeypatch):
+    monkeypatch.setattr("cbrain_cli.handlers.tasks.list_tasks", lambda _: [{"id": 1}])
+    monkeypatch.setattr("cbrain_cli.handlers.tasks_fmt.print_task_data", lambda *_: None)
+    assert handle_task_list(make_args()) is None
+
+
+def test_handle_project_show_no_project_prints_message(monkeypatch, capsys):
+    """show_project returning None with no project_id prints 'no project' message, not 1."""
+    monkeypatch.setattr("cbrain_cli.handlers.projects.show_project", lambda _: None)
+    monkeypatch.setattr(
+        "cbrain_cli.handlers.projects_fmt.print_no_project",
+        lambda args: print("No active project."),
+    )
+    from cbrain_cli.handlers import handle_project_show
+
+    result = handle_project_show(make_args(project_id=None))
+    assert result is None
+    assert "No active project." in capsys.readouterr().out
+
+
+def test_handle_project_unswitch_always_returns_none(monkeypatch):
+    monkeypatch.setattr("cbrain_cli.handlers.projects.unswitch_project", lambda _: None)
+    monkeypatch.setattr("cbrain_cli.handlers.projects_fmt.print_unswitch_result", lambda *_: None)
+    assert handle_project_unswitch(make_args()) is None
+
+
+def test_handle_project_switch_json_output(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "cbrain_cli.handlers.projects.switch_project",
+        lambda _: {"id": 5, "name": "Alpha"},
+    )
+    handle_project_switch(make_args(json=True, group_id="5"))
+    assert parse_json_output(capsys)["id"] == 5
+
+
+def test_handle_project_unswitch_json_output(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "cbrain_cli.handlers.projects.unswitch_project",
+        lambda _: {"previous_group_id": 5, "current_group_id": None},
+    )
+    handle_project_unswitch(make_args(json=True))
+    assert parse_json_output(capsys)["current_group_id"] is None
+
+
+def test_handle_task_show_success_returns_none(monkeypatch):
+    monkeypatch.setattr(
+        "cbrain_cli.handlers.tasks.show_task",
+        lambda _: {"id": 2, "status": "Ready"},
+    )
+    monkeypatch.setattr("cbrain_cli.handlers.tasks_fmt.print_task_details", lambda *_: None)
+    assert handle_task_show(make_args(task=2)) is None
+
+
+def test_handle_task_show_none_returns_1(monkeypatch):
+    monkeypatch.setattr("cbrain_cli.handlers.tasks.show_task", lambda _: None)
+    fmt_called = []
+    monkeypatch.setattr(
+        "cbrain_cli.handlers.tasks_fmt.print_task_details",
+        lambda *_: fmt_called.append(True),
+    )
+    assert handle_task_show(make_args(task=2)) == 1
+    assert fmt_called == []
+
+
+def test_list_handler_validation_error_returns_1(monkeypatch):
+    monkeypatch.setattr(
+        "cbrain_cli.handlers.tasks.list_tasks",
+        MagicMock(side_effect=CliValidationError("bad filter")),
+    )
+    assert handle_errors(handle_task_list)(make_args()) == 1
+
+
+def test_user_details_sends_current_token_in_header(monkeypatch, capture_urlopen):
+    """auth_headers(api_token) is called inside user_details, not at import time."""
+    patch_module_locals(monkeypatch, "cbrain_cli.users")
+    monkeypatch.setattr("cbrain_cli.users.api_token", "new-token")
+
+    configure, captured = capture_urlopen
+    configure({"id": 1, "login": "admin"})
+    user_details(1)
+
+    assert captured["headers"].get("Authorization") == "Bearer new-token"
+
+
+def test_whoami_user_version_does_not_print_debug_lines(monkeypatch, capsys):
+    """whoami_user with version=True must not print DEBUG: lines."""
+    patch_module_locals(monkeypatch, "cbrain_cli.users", user_id=1)
+
+    monkeypatch.setattr(
+        "cbrain_cli.users.user_details",
+        lambda _: {"id": 1, "login": "admin", "full_name": "Admin"},
+    )
+
+    mock_http_response = MagicMock()
+    mock_http_response.__enter__.return_value.read.return_value = (
+        b'{"user_id": 1, "cbrain_api_token": "test-token"}'
+    )
+    mock_http_response.__exit__.return_value = False
+    monkeypatch.setattr("urllib.request.urlopen", MagicMock(return_value=mock_http_response))
+
+    whoami_user(make_args(version=True))
+
+    out = capsys.readouterr().out
+    assert "DEBUG:" not in out

--- a/tests/test_handlers_ops.py
+++ b/tests/test_handlers_ops.py
@@ -154,7 +154,9 @@ def test_handle_file_copy_failure_returns_1(monkeypatch):
         "cbrain_cli.handlers.files.copy_file",
         lambda _: ({"error": "fail"}, 400),
     )
-    monkeypatch.setattr("cbrain_cli.handlers.files_fmt.print_move_copy_result", lambda *_, **__: None)
+    monkeypatch.setattr(
+        "cbrain_cli.handlers.files_fmt.print_move_copy_result", lambda *_, **__: None
+    )
     assert handlers.handle_file_copy(make_args()) == 1
 
 
@@ -177,14 +179,18 @@ def test_handle_tool_config_boutiques_descriptor(monkeypatch, capsys):
 
 
 @pytest.mark.parametrize("handler_name,data_fn,fmt_fn,sample,arg_kwargs", SHOW_HANDLER_CASES)
-def test_show_handler_success(monkeypatch, capsys, handler_name, data_fn, fmt_fn, sample, arg_kwargs):
+def test_show_handler_success(
+    monkeypatch, capsys, handler_name, data_fn, fmt_fn, sample, arg_kwargs
+):
     monkeypatch.setattr(data_fn, lambda _: sample)
     getattr(handlers, handler_name)(make_args(**arg_kwargs))
     assert capsys.readouterr().out
 
 
 @pytest.mark.parametrize("handler_name,data_fn,fmt_fn,sample,arg_kwargs", SHOW_HANDLER_CASES)
-def test_show_handler_none_returns_1(monkeypatch, handler_name, data_fn, fmt_fn, sample, arg_kwargs):
+def test_show_handler_none_returns_1(
+    monkeypatch, handler_name, data_fn, fmt_fn, sample, arg_kwargs
+):
     fmt_called = []
     monkeypatch.setattr(data_fn, lambda _: None)
     monkeypatch.setattr(fmt_fn, lambda *_: fmt_called.append(True))

--- a/tests/test_handlers_ops.py
+++ b/tests/test_handlers_ops.py
@@ -1,0 +1,192 @@
+import pytest
+
+import cbrain_cli.handlers as handlers
+from tests.conftest import make_args
+
+SHOW_HANDLER_CASES = [
+    (
+        "handle_file_show",
+        "cbrain_cli.handlers.files.show_file",
+        "cbrain_cli.handlers.files_fmt.print_file_details",
+        {"id": 1, "name": "f.txt"},
+        {"file": 1},
+    ),
+    (
+        "handle_dataprovider_show",
+        "cbrain_cli.handlers.data_providers.show_data_provider",
+        "cbrain_cli.handlers.data_providers_fmt.print_provider_details",
+        {"id": 2, "name": "LocalDP"},
+        {"id": 2},
+    ),
+    (
+        "handle_tool_show",
+        "cbrain_cli.handlers.tools.show_tool",
+        "cbrain_cli.handlers.tools_fmt.print_tool_details",
+        {"id": 3, "name": "Tool"},
+        {"id": 3},
+    ),
+    (
+        "handle_tool_config_show",
+        "cbrain_cli.handlers.tool_configs.show_tool_config",
+        "cbrain_cli.handlers.tool_configs_fmt.print_tool_config_details",
+        {"id": 4, "tool_id": 1},
+        {"id": 4},
+    ),
+    (
+        "handle_tag_show",
+        "cbrain_cli.handlers.tags.show_tag",
+        "cbrain_cli.handlers.tags_fmt.print_tag_details",
+        {"id": 5, "name": "tag"},
+        {"id": 5},
+    ),
+    (
+        "handle_background_show",
+        "cbrain_cli.handlers.background_activities.show_background_activity",
+        "cbrain_cli.handlers.background_activities_fmt.print_activity_details",
+        {"id": 6, "status": "Done"},
+        {"id": 6},
+    ),
+    (
+        "handle_remote_resource_show",
+        "cbrain_cli.handlers.remote_resources.show_remote_resource",
+        "cbrain_cli.handlers.remote_resources_fmt.print_resource_details",
+        {"id": 7, "name": "rr"},
+        {"remote_resource": 7},
+    ),
+]
+
+FILE_UPLOAD_CASES = [
+    (({"error": "fail"}, 400, "f.txt", 10, 1), 1),
+    (({"notice": "ok"}, 201, "f.txt", 10, 1), None),
+]
+
+TAG_HANDLER_CASES = [
+    (
+        "handle_tag_create",
+        "cbrain_cli.handlers.tags.create_tag",
+        "cbrain_cli.handlers.tags_fmt.print_tag_operation_result",
+        make_args(),
+        (None, False, "bad", 422),
+        1,
+    ),
+    (
+        "handle_tag_create",
+        "cbrain_cli.handlers.tags.create_tag",
+        "cbrain_cli.handlers.tags_fmt.print_tag_operation_result",
+        make_args(),
+        ({"id": 1}, True, None, 201),
+        None,
+    ),
+    (
+        "handle_tag_update",
+        "cbrain_cli.handlers.tags.update_tag",
+        "cbrain_cli.handlers.tags_fmt.print_tag_operation_result",
+        make_args(tag_id=1),
+        (None, False, "bad", 422),
+        1,
+    ),
+    (
+        "handle_tag_delete",
+        "cbrain_cli.handlers.tags.delete_tag",
+        "cbrain_cli.handlers.tags_fmt.print_tag_operation_result",
+        make_args(tag_id=1),
+        (True, None, 200),
+        None,
+    ),
+]
+
+
+def test_handle_dataprovider_is_alive_prints_json(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "cbrain_cli.handlers.data_providers.is_alive",
+        lambda _: {"alive": True},
+    )
+    handlers.handle_dataprovider_is_alive(make_args(id=1))
+    assert '"alive": true' in capsys.readouterr().out
+
+
+def test_handle_dataprovider_is_alive_none_returns_1(monkeypatch):
+    monkeypatch.setattr("cbrain_cli.handlers.data_providers.is_alive", lambda _: None)
+    assert handlers.handle_dataprovider_is_alive(make_args(id=1)) == 1
+
+
+def test_handle_dataprovider_delete_unregistered_prints_json(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "cbrain_cli.handlers.data_providers.delete_unregistered_files",
+        lambda _: {"deleted": 2},
+    )
+    handlers.handle_dataprovider_delete_unregistered(make_args(id=1))
+    assert '"deleted": 2' in capsys.readouterr().out
+
+
+def test_handle_project_show_with_id(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "cbrain_cli.handlers.projects.show_project",
+        lambda _: {"id": 9, "name": "Proj", "type": "Group"},
+    )
+    handlers.handle_project_show(make_args(project_id=9))
+    assert "PROJECT DETAILS" in capsys.readouterr().out
+
+
+def test_handle_project_switch_none_returns_1(monkeypatch):
+    monkeypatch.setattr("cbrain_cli.handlers.projects.switch_project", lambda _: None)
+    assert handlers.handle_project_switch(make_args(group_id="5")) == 1
+
+
+@pytest.mark.parametrize("upload_result,expected", FILE_UPLOAD_CASES)
+def test_handle_file_upload(monkeypatch, upload_result, expected):
+    monkeypatch.setattr("cbrain_cli.handlers.files.upload_file", lambda _: upload_result)
+    monkeypatch.setattr("cbrain_cli.handlers.files_fmt.print_upload_result", lambda *_: None)
+    result = handlers.handle_file_upload(make_args())
+    assert result is expected if expected is None else result == expected
+
+
+@pytest.mark.parametrize("handler,data_fn,fmt_fn,args,api_result,expected", TAG_HANDLER_CASES)
+def test_tag_handlers(monkeypatch, handler, data_fn, fmt_fn, args, api_result, expected):
+    monkeypatch.setattr(data_fn, lambda _: api_result)
+    monkeypatch.setattr(fmt_fn, lambda *_, **__: None)
+    result = getattr(handlers, handler)(args)
+    assert result is expected if expected is None else result == expected
+
+
+def test_handle_file_copy_failure_returns_1(monkeypatch):
+    monkeypatch.setattr(
+        "cbrain_cli.handlers.files.copy_file",
+        lambda _: ({"error": "fail"}, 400),
+    )
+    monkeypatch.setattr("cbrain_cli.handlers.files_fmt.print_move_copy_result", lambda *_, **__: None)
+    assert handlers.handle_file_copy(make_args()) == 1
+
+
+def test_handle_file_delete_success(monkeypatch):
+    monkeypatch.setattr(
+        "cbrain_cli.handlers.files.delete_file",
+        lambda _: {"deleted": 1},
+    )
+    monkeypatch.setattr("cbrain_cli.handlers.files_fmt.print_delete_result", lambda *_: None)
+    assert handlers.handle_file_delete(make_args(file_id=1)) is None
+
+
+def test_handle_tool_config_boutiques_descriptor(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "cbrain_cli.handlers.tool_configs.tool_config_boutiques_descriptor",
+        lambda _: {"name": "Tool"},
+    )
+    handlers.handle_tool_config_boutiques_descriptor(make_args(id=1))
+    assert '"name": "Tool"' in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("handler_name,data_fn,fmt_fn,sample,arg_kwargs", SHOW_HANDLER_CASES)
+def test_show_handler_success(monkeypatch, capsys, handler_name, data_fn, fmt_fn, sample, arg_kwargs):
+    monkeypatch.setattr(data_fn, lambda _: sample)
+    getattr(handlers, handler_name)(make_args(**arg_kwargs))
+    assert capsys.readouterr().out
+
+
+@pytest.mark.parametrize("handler_name,data_fn,fmt_fn,sample,arg_kwargs", SHOW_HANDLER_CASES)
+def test_show_handler_none_returns_1(monkeypatch, handler_name, data_fn, fmt_fn, sample, arg_kwargs):
+    fmt_called = []
+    monkeypatch.setattr(data_fn, lambda _: None)
+    monkeypatch.setattr(fmt_fn, lambda *_: fmt_called.append(True))
+    assert getattr(handlers, handler_name)(make_args(**arg_kwargs)) == 1
+    assert fmt_called == []

--- a/tests/test_main_dispatch.py
+++ b/tests/test_main_dispatch.py
@@ -48,7 +48,9 @@ def test_main_version_does_not_create_config_dir(monkeypatch, tmp_path):
     assert not (home / ".config").exists()
 
 
-def test_main_task_list_bourreau_id_parses_and_dispatches(monkeypatch, fake_credentials, capture_urlopen):
+def test_main_task_list_bourreau_id_parses_and_dispatches(
+    monkeypatch, fake_credentials, capture_urlopen
+):
     patch_module_locals(monkeypatch, "cbrain_cli.data.tasks")
     configure, captured = capture_urlopen
     configure([])

--- a/tests/test_main_dispatch.py
+++ b/tests/test_main_dispatch.py
@@ -1,0 +1,69 @@
+import importlib
+from pathlib import Path
+
+from tests.conftest import patch_module_locals, run_main
+
+
+def test_main_invalid_pagination_skips_network(monkeypatch):
+    urlopen_called = []
+
+    def fake_urlopen(*_args, **_kwargs):
+        urlopen_called.append(True)
+        raise AssertionError("urlopen must not be called for invalid pagination")
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    result = run_main(monkeypatch, ["cbrain", "task", "list", "--page", "0"])
+    assert result == 1
+    assert urlopen_called == []
+
+
+def test_main_logout_bypasses_authentication(monkeypatch, sessions_creds_file, capsys):
+    sessions_creds_file.write_text("not valid json")
+    auth_checks = []
+    monkeypatch.setattr(
+        "cbrain_cli.main.is_authenticated",
+        lambda: auth_checks.append(True) or True,
+    )
+    result = run_main(monkeypatch, ["cbrain", "logout"])
+    assert result == 0
+    assert auth_checks == []
+    assert not sessions_creds_file.exists()
+
+
+def test_config_import_does_not_create_home_dir(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    import cbrain_cli.config as config_mod
+
+    importlib.reload(config_mod)
+    assert not (home / ".config" / "cbrain").exists()
+
+
+def test_main_version_does_not_create_config_dir(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    run_main(monkeypatch, ["cbrain", "version"])
+    assert not (home / ".config").exists()
+
+
+def test_main_task_list_bourreau_id_parses_and_dispatches(monkeypatch, fake_credentials, capture_urlopen):
+    patch_module_locals(monkeypatch, "cbrain_cli.data.tasks")
+    configure, captured = capture_urlopen
+    configure([])
+    result = run_main(monkeypatch, ["cbrain", "task", "list", "bourreau-id", "7"])
+    assert result is None
+    assert "bourreau_id=7" in captured["url"]
+
+
+def test_main_no_command_prints_help(capsys):
+    from cbrain_cli.main import main
+
+    assert main([]) is None
+    assert "usage:" in capsys.readouterr().out.lower()
+
+
+def test_main_missing_subcommand_action_returns_1(monkeypatch, fake_credentials, capsys):
+    result = run_main(monkeypatch, ["cbrain", "file"])
+    assert result == 1

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,46 @@
+import pytest
+
+from cbrain_cli.cli_utils import CliValidationError, pagination
+from tests.conftest import make_args
+
+
+@pytest.mark.parametrize(
+    "per_page,valid",
+    [(4, False), (5, True), (25, True), (1000, True), (1001, False)],
+)
+def test_per_page_boundary(per_page, valid):
+    args = make_args(per_page=per_page)
+    if valid:
+        result = pagination(args, {})
+        assert result["per_page"] == str(per_page)
+    else:
+        with pytest.raises(CliValidationError) as exc_info:
+            pagination(args, {})
+        assert exc_info.value.field == "--per-page"
+
+
+@pytest.mark.parametrize("page,valid", [(0, False), (1, True), (10, True)])
+def test_page_boundary(page, valid):
+    args = make_args(page=page)
+    if valid:
+        result = pagination(args, {})
+        assert result["page"] == str(page)
+    else:
+        with pytest.raises(CliValidationError) as exc_info:
+            pagination(args, {})
+        assert exc_info.value.field == "--page"
+
+
+def test_pagination_adds_both_keys_to_query_params():
+    params = {"existing": "value"}
+    result = pagination(make_args(page=2, per_page=50), params)
+    assert result["page"] == "2"
+    assert result["per_page"] == "50"
+    assert result["existing"] == "value"
+
+
+def test_pagination_returns_query_params():
+    """Return value is the same dict that was mutated."""
+    params = {}
+    result = pagination(make_args(), params)
+    assert result is params

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,76 @@
+from cbrain_cli.main import build_parser
+
+
+def test_build_parser_has_core_commands():
+    parser, _command_parsers = build_parser()
+    assert parser.parse_args(["logout"]).command == "logout"
+    assert parser.parse_args(["version"]).command == "version"
+    assert parser.parse_args(["task", "list"]).action == "list"
+    assert parser.parse_args(["project", "unswitch"]).action == "unswitch"
+
+
+def test_task_list_bourreau_id_args():
+    parser, _command_parsers = build_parser()
+    args = parser.parse_args(["task", "list", "bourreau-id", "7"])
+    assert args.command == "task"
+    assert args.action == "list"
+    assert args.filter_name == "bourreau-id"
+    assert args.bourreau_id == 7
+
+
+def test_project_unswitch_subcommand():
+    parser, _command_parsers = build_parser()
+    args = parser.parse_args(["project", "unswitch"])
+    assert args.command == "project"
+    assert args.action == "unswitch"
+
+
+def test_global_json_flag_on_task_list():
+    parser, _command_parsers = build_parser()
+    args = parser.parse_args(["--json", "task", "list"])
+    assert args.json is True
+    assert args.jsonl is False
+
+
+def test_global_jsonl_flag_on_task_list():
+    parser, _command_parsers = build_parser()
+    args = parser.parse_args(["--jsonl", "task", "list"])
+    assert args.jsonl is True
+    assert args.json is False
+
+
+def test_pagination_flags_on_file_list():
+    parser, _command_parsers = build_parser()
+    args = parser.parse_args(["file", "list", "--page", "2", "--per-page", "50"])
+    assert args.page == 2
+    assert args.per_page == 50
+
+
+def test_pagination_flags_on_tool_list():
+    parser, _command_parsers = build_parser()
+    args = parser.parse_args(["tool", "list", "--page", "3", "--per-page", "100"])
+    assert args.page == 3
+    assert args.per_page == 100
+
+
+def test_logout_command_sets_handler():
+    parser, _command_parsers = build_parser()
+    args = parser.parse_args(["logout"])
+    assert args.command == "logout"
+    assert callable(args.func)
+
+
+def test_command_parsers_include_model_commands():
+    _parser, command_parsers = build_parser()
+    for command in (
+        "file",
+        "dataprovider",
+        "project",
+        "tool",
+        "tool-config",
+        "tag",
+        "background",
+        "task",
+        "remote-resource",
+    ):
+        assert command in command_parsers

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,0 +1,133 @@
+import json
+import urllib.error
+from unittest.mock import MagicMock
+
+import pytest
+
+from cbrain_cli.cli_utils import CliApiError, CliValidationError
+from cbrain_cli.data.data_providers import show_data_provider
+from cbrain_cli.data.projects import list_projects, show_project, switch_project, unswitch_project
+from tests.conftest import TOKEN, URL, make_args, patch_module_locals
+
+
+@pytest.fixture(autouse=True)
+def _patch_projects_locals(monkeypatch):
+    """Patch data.projects module-local copies of api_token / cbrain_url."""
+    patch_module_locals(
+        monkeypatch,
+        "cbrain_cli.data.projects",
+        "cbrain_cli.data.data_providers",
+    )
+
+
+def test_list_projects_returns_list(mock_urlopen):
+    mock_urlopen([{"id": 1, "name": "Project A"}])
+    result = list_projects(make_args())
+    assert isinstance(result, list)
+    assert result[0]["id"] == 1
+
+
+def test_list_projects_empty_list_is_not_error(mock_urlopen):
+    """[] response is valid — empty list regression."""
+    mock_urlopen([])
+    assert list_projects(make_args()) == []
+
+
+def test_show_project_with_id_http_404_raises_cli_api_error(monkeypatch):
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        MagicMock(side_effect=urllib.error.HTTPError(URL, 404, "Not Found", {}, None)),
+    )
+    with pytest.raises(CliApiError):
+        show_project(make_args(project_id=5))
+
+
+def test_show_project_no_credentials_returns_none(creds_file):
+    result = show_project(make_args(project_id=None))
+    assert result is None
+
+
+def test_show_project_by_id_not_found_raises(monkeypatch):
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        MagicMock(side_effect=urllib.error.HTTPError(URL, 404, "Not Found", {}, None)),
+    )
+    with pytest.raises(CliApiError, match="Project with ID 5 not found"):
+        show_project(make_args(project_id=5))
+
+
+def test_show_project_no_current_group_returns_none(creds_file):
+    creds_file.write_text(json.dumps({"api_token": TOKEN}))
+    result = show_project(make_args(project_id=None))
+    assert result is None
+
+
+def test_show_project_stale_group_raises_and_cleans_credentials(monkeypatch, creds_file):
+    """When saved current_group_id returns 404, credentials cleaned and CliApiError raised."""
+    creds_file.write_text(json.dumps({"api_token": TOKEN, "current_group_id": 99}))
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        MagicMock(side_effect=urllib.error.HTTPError(URL, 404, "Not Found", {}, None)),
+    )
+    with pytest.raises(CliApiError):
+        show_project(make_args(project_id=None))
+    saved = json.loads(creds_file.read_text())
+    assert "current_group_id" not in saved
+
+
+def test_switch_project_missing_group_id_raises():
+    with pytest.raises(CliValidationError):
+        switch_project(make_args(group_id=None))
+
+
+def test_switch_project_all_raises():
+    with pytest.raises(CliValidationError):
+        switch_project(make_args(group_id="all"))
+
+
+def test_switch_project_invalid_string_raises():
+    with pytest.raises(CliValidationError, match="[Ii]nvalid"):
+        switch_project(make_args(group_id="abc"))
+
+
+def test_switch_project_saves_credentials(monkeypatch, creds_file):
+    creds_file.write_text(json.dumps({"api_token": TOKEN}))
+
+    session_delete_response = MagicMock()
+    session_delete_response.__enter__.return_value.read.return_value = b""
+    session_delete_response.__enter__.return_value.status = 200
+    project_details_response = MagicMock()
+    project_details_response.__enter__.return_value.read.return_value = json.dumps(
+        {"id": 5, "name": "MyGroup"}
+    ).encode()
+    project_details_response.__enter__.return_value.status = 200
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        MagicMock(side_effect=[session_delete_response, project_details_response]),
+    )
+
+    result = switch_project(make_args(group_id="5"))
+    assert result["id"] == 5
+    saved = json.loads(creds_file.read_text())
+    assert saved["current_group_id"] == 5
+
+
+def test_unswitch_project_removes_group_from_credentials(creds_file, mock_urlopen):
+    creds_file.write_text(
+        json.dumps({"api_token": TOKEN, "current_group_id": 5, "current_group_name": "G"})
+    )
+    mock_urlopen({})
+    result = unswitch_project(make_args())
+    assert result["current_group_id"] is None
+    saved = json.loads(creds_file.read_text())
+    assert "current_group_id" not in saved
+
+
+def test_show_data_provider_id_none_silently_returns_list(mock_urlopen):
+    """Missing id falls back to list_data_providers — returns list, does not raise.
+
+    Documented as a regression test so any silent behaviour change is caught.
+    """
+    mock_urlopen([{"id": 1}, {"id": 2}])
+    result = show_data_provider(make_args(id=None))
+    assert isinstance(result, list)

--- a/tests/test_remote_resources.py
+++ b/tests/test_remote_resources.py
@@ -1,0 +1,34 @@
+import pytest
+
+from cbrain_cli.cli_utils import CliValidationError
+from cbrain_cli.data.remote_resources import list_remote_resources, show_remote_resource
+from tests.conftest import make_args as _args
+from tests.conftest import patch_module_locals
+
+
+@pytest.fixture(autouse=True)
+def _patch_locals(monkeypatch):
+    patch_module_locals(monkeypatch, "cbrain_cli.data.remote_resources")
+
+
+def test_list_remote_resources_returns_list(mock_urlopen):
+    mock_urlopen([{"id": 1, "name": "mainbrain"}])
+    result = list_remote_resources(_args())
+    assert isinstance(result, list)
+    assert result[0]["id"] == 1
+
+
+def test_list_remote_resources_empty_list_is_not_error(mock_urlopen):
+    mock_urlopen([])
+    assert list_remote_resources(_args()) == []
+
+
+def test_show_remote_resource_missing_id_raises():
+    with pytest.raises(CliValidationError):
+        show_remote_resource(_args(remote_resource=None))
+
+
+def test_show_remote_resource_returns_dict(mock_urlopen):
+    mock_urlopen({"id": 3, "name": "mainbrain", "online": True})
+    result = show_remote_resource(_args(remote_resource=3))
+    assert result["id"] == 3

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -33,9 +33,7 @@ def test_create_session_empty_password_raises(monkeypatch, sessions_creds_file):
 def test_create_session_no_token_in_response_returns_1(monkeypatch, sessions_creds_file, capsys):
     monkeypatch.setattr("builtins.input", lambda _: "admin")
     monkeypatch.setattr("getpass.getpass", lambda _: "secret")
-    monkeypatch.setattr(
-        "cbrain_cli.sessions.api_post_form", lambda *_: {"user_id": 1}
-    )
+    monkeypatch.setattr("cbrain_cli.sessions.api_post_form", lambda *_: {"user_id": 1})
     result = create_session(argparse.Namespace())
     assert result == 1
     assert "Login failed" in capsys.readouterr().out
@@ -66,7 +64,9 @@ def test_logout_session_corrupt_file_removes_it(sessions_creds_file, capsys):
     assert not sessions_creds_file.exists()
 
 
-def test_logout_session_no_api_token_removes_file_without_http(monkeypatch, sessions_creds_file, capsys):
+def test_logout_session_no_api_token_removes_file_without_http(
+    monkeypatch, sessions_creds_file, capsys
+):
     """When sessions module-local api_token is None, logout removes file with no HTTP call."""
     sessions_creds_file.write_text('{"api_token": "tok", "cbrain_url": "http://localhost:3000"}')
     # explicitly null out the module-local copies (not reset by _reset_globals)
@@ -77,7 +77,9 @@ def test_logout_session_no_api_token_removes_file_without_http(monkeypatch, sess
     assert not sessions_creds_file.exists()
 
 
-def test_logout_session_success_sends_delete_and_removes_file(monkeypatch, sessions_creds_file, capsys):
+def test_logout_session_success_sends_delete_and_removes_file(
+    monkeypatch, sessions_creds_file, capsys
+):
     sessions_creds_file.write_text('{"api_token": "tok", "cbrain_url": "http://localhost:3000"}')
     monkeypatch.setattr("cbrain_cli.sessions.api_token", "tok")
     monkeypatch.setattr("cbrain_cli.sessions.cbrain_url", "http://localhost:3000")

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,0 +1,118 @@
+import argparse
+import urllib.error
+from unittest.mock import MagicMock
+
+import pytest
+
+from cbrain_cli.cli_utils import CliValidationError
+from cbrain_cli.sessions import create_session, logout_session
+
+
+def test_create_session_already_logged_in(sessions_creds_file, capsys):
+    sessions_creds_file.write_text("{}")
+    result = create_session(argparse.Namespace())
+    assert result == 1
+    assert "Already logged in" in capsys.readouterr().out
+
+
+def test_create_session_empty_username_raises(monkeypatch, sessions_creds_file):
+    inputs = iter(["http://localhost:3000", ""])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    with pytest.raises(CliValidationError, match="[Uu]sername"):
+        create_session(argparse.Namespace())
+
+
+def test_create_session_empty_password_raises(monkeypatch, sessions_creds_file):
+    inputs = iter(["http://localhost:3000", "admin"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    monkeypatch.setattr("getpass.getpass", lambda _: "")
+    with pytest.raises(CliValidationError, match="[Pp]assword"):
+        create_session(argparse.Namespace())
+
+
+def test_create_session_no_token_in_response_returns_1(monkeypatch, sessions_creds_file, capsys):
+    monkeypatch.setattr("builtins.input", lambda _: "admin")
+    monkeypatch.setattr("getpass.getpass", lambda _: "secret")
+    monkeypatch.setattr(
+        "cbrain_cli.sessions.api_post_form", lambda *_: {"user_id": 1}
+    )
+    result = create_session(argparse.Namespace())
+    assert result == 1
+    assert "Login failed" in capsys.readouterr().out
+
+
+def test_create_session_success_saves_credentials(monkeypatch, sessions_creds_file):
+    monkeypatch.setattr("builtins.input", lambda _: "admin")
+    monkeypatch.setattr("getpass.getpass", lambda _: "secret")
+    monkeypatch.setattr(
+        "cbrain_cli.sessions.api_post_form",
+        lambda *_: {"cbrain_api_token": "tok123", "user_id": 99},
+    )
+    result = create_session(argparse.Namespace())
+    assert result == 0
+    assert sessions_creds_file.exists()
+
+
+def test_logout_session_not_logged_in(sessions_creds_file, capsys):
+    result = logout_session(argparse.Namespace())
+    assert result == 0
+    assert "Not logged in" in capsys.readouterr().out
+
+
+def test_logout_session_corrupt_file_removes_it(sessions_creds_file, capsys):
+    sessions_creds_file.write_text("not valid json")
+    result = logout_session(argparse.Namespace())
+    assert result == 0
+    assert not sessions_creds_file.exists()
+
+
+def test_logout_session_no_api_token_removes_file_without_http(monkeypatch, sessions_creds_file, capsys):
+    """When sessions module-local api_token is None, logout removes file with no HTTP call."""
+    sessions_creds_file.write_text('{"api_token": "tok", "cbrain_url": "http://localhost:3000"}')
+    # explicitly null out the module-local copies (not reset by _reset_globals)
+    monkeypatch.setattr("cbrain_cli.sessions.api_token", None)
+    monkeypatch.setattr("cbrain_cli.sessions.cbrain_url", None)
+    result = logout_session(argparse.Namespace())
+    assert result == 0
+    assert not sessions_creds_file.exists()
+
+
+def test_logout_session_success_sends_delete_and_removes_file(monkeypatch, sessions_creds_file, capsys):
+    sessions_creds_file.write_text('{"api_token": "tok", "cbrain_url": "http://localhost:3000"}')
+    monkeypatch.setattr("cbrain_cli.sessions.api_token", "tok")
+    monkeypatch.setattr("cbrain_cli.sessions.cbrain_url", "http://localhost:3000")
+    monkeypatch.setattr("cbrain_cli.sessions.api_send", lambda *_, **__: ({}, 200))
+    result = logout_session(argparse.Namespace())
+    assert result == 0
+    assert not sessions_creds_file.exists()
+    assert "Successfully logged out" in capsys.readouterr().out
+
+
+def test_logout_session_server_401_still_removes_file(monkeypatch, sessions_creds_file, capsys):
+    sessions_creds_file.write_text('{"api_token": "tok", "cbrain_url": "http://localhost:3000"}')
+    monkeypatch.setattr("cbrain_cli.sessions.api_token", "tok")
+    monkeypatch.setattr("cbrain_cli.sessions.cbrain_url", "http://localhost:3000")
+    monkeypatch.setattr(
+        "cbrain_cli.sessions.api_send",
+        MagicMock(
+            side_effect=urllib.error.HTTPError(
+                "http://localhost:3000/session", 401, "Unauthorized", {}, None
+            )
+        ),
+    )
+    result = logout_session(argparse.Namespace())
+    assert result == 0
+    assert not sessions_creds_file.exists()
+    assert "Session already expired" in capsys.readouterr().out
+
+
+def test_create_session_uses_default_url(monkeypatch, sessions_creds_file):
+    inputs = iter(["", "admin"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    monkeypatch.setattr("getpass.getpass", lambda _: "secret")
+    monkeypatch.setattr(
+        "cbrain_cli.sessions.api_post_form",
+        lambda url, _: {"cbrain_api_token": "tok123", "user_id": 99},
+    )
+    result = create_session(argparse.Namespace())
+    assert result == 0

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,0 +1,74 @@
+import pytest
+
+from cbrain_cli.cli_utils import CliValidationError
+from cbrain_cli.data.tags import create_tag, delete_tag, list_tags, show_tag, update_tag
+from tests.conftest import make_args as _args
+from tests.conftest import patch_module_locals
+
+
+@pytest.fixture(autouse=True)
+def _patch_locals(monkeypatch):
+    patch_module_locals(monkeypatch, "cbrain_cli.data.tags")
+
+
+def _tag_args(**kwargs):
+    return _args(name="mytag", user_id=1, group_id=2, **kwargs)
+
+
+def test_list_tags_returns_list(mock_urlopen):
+    mock_urlopen([{"id": 1, "name": "mytag"}])
+    result = list_tags(_args())
+    assert isinstance(result, list)
+    assert result[0]["id"] == 1
+
+
+def test_list_tags_empty_list_is_not_error(mock_urlopen):
+    mock_urlopen([])
+    assert list_tags(_args()) == []
+
+
+def test_show_tag_missing_id_raises():
+    with pytest.raises(CliValidationError):
+        show_tag(_args(id=None))
+
+
+def test_show_tag_returns_dict(mock_urlopen):
+    mock_urlopen({"id": 5, "name": "mytag"})
+    result = show_tag(_args(id=5))
+    assert result["id"] == 5
+
+
+def test_create_tag_missing_name_raises():
+    with pytest.raises(CliValidationError):
+        create_tag(_args(name=None, user_id=1, group_id=2))
+
+
+def test_create_tag_returns_tuple_on_success(mock_urlopen):
+    mock_urlopen({"id": 7, "name": "mytag"}, status=201)
+    data, success, error_msg, status = create_tag(_tag_args())
+    assert success is True
+    assert status == 201
+    assert data["id"] == 7
+
+
+def test_update_tag_missing_tag_id_raises():
+    with pytest.raises(CliValidationError):
+        update_tag(_tag_args(tag_id=None))
+
+
+def test_update_tag_returns_tuple_on_success(mock_urlopen):
+    mock_urlopen({"id": 7, "name": "updated"}, status=200)
+    data, success, error_msg, status = update_tag(_tag_args(tag_id=7))
+    assert success is True
+
+
+def test_delete_tag_missing_tag_id_raises():
+    with pytest.raises(CliValidationError):
+        delete_tag(_args(tag_id=None))
+
+
+def test_delete_tag_returns_tuple_on_success(mock_urlopen):
+    mock_urlopen({}, status=200)
+    success, error_msg, status = delete_tag(_args(tag_id=7))
+    assert success is True
+    assert status == 200

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -2,8 +2,7 @@ import pytest
 
 from cbrain_cli.cli_utils import CliValidationError
 from cbrain_cli.data.tasks import list_tasks, show_task
-from tests.conftest import make_args
-from tests.conftest import patch_module_locals
+from tests.conftest import make_args, patch_module_locals
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,78 @@
+import pytest
+
+from cbrain_cli.cli_utils import CliValidationError
+from cbrain_cli.data.tasks import list_tasks, show_task
+from tests.conftest import make_args
+from tests.conftest import patch_module_locals
+
+
+@pytest.fixture(autouse=True)
+def _patch_tasks_locals(monkeypatch):
+    patch_module_locals(monkeypatch, "cbrain_cli.data.tasks")
+
+
+def make_task_args(**kwargs):
+    kwargs.setdefault("filter_name", None)
+    kwargs.setdefault("bourreau_id", None)
+    return make_args(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "filter_name,bourreau_id,raises",
+    [
+        (None, None, False),
+        ("bourreau-id", 7, False),
+        ("bourreau-id", None, True),
+        (None, 7, True),
+    ],
+)
+def test_list_tasks_filter_validation(filter_name, bourreau_id, raises, mock_urlopen):
+    if not raises:
+        mock_urlopen([{"id": 1}])
+    args = make_task_args(filter_name=filter_name, bourreau_id=bourreau_id)
+    if raises:
+        with pytest.raises(CliValidationError):
+            list_tasks(args)
+    else:
+        result = list_tasks(args)
+        assert isinstance(result, list)
+
+
+def test_list_tasks_empty_list_is_not_error(mock_urlopen):
+    """Empty list response must not raise — empty-list regression."""
+    mock_urlopen([])
+    assert list_tasks(make_task_args()) == []
+
+
+def test_show_task_missing_id_raises():
+    with pytest.raises(CliValidationError):
+        show_task(make_task_args(task=None))
+
+
+def test_show_task_returns_dict(mock_urlopen):
+    mock_urlopen({"id": 2, "type": "CbrainTask::Diagnostics"})
+    result = show_task(make_task_args(task=2))
+    assert result["id"] == 2
+
+
+def test_list_tasks_sends_bourreau_id_query(capture_urlopen):
+    configure, captured = capture_urlopen
+    configure([])
+    list_tasks(make_task_args(filter_name="bourreau-id", bourreau_id=7))
+    assert "bourreau_id=7" in captured["url"]
+
+
+def test_list_tasks_unsupported_filter_raises():
+    with pytest.raises(CliValidationError):
+        list_tasks(make_task_args(filter_name="other", bourreau_id=1))
+
+
+def test_operation_task_prints_json(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "cbrain_cli.data.tasks.api_send",
+        lambda *_, **__: ({"status": "ok"}, 200),
+    )
+    from cbrain_cli.data.tasks import operation_task
+
+    operation_task(make_task_args())
+    assert '"status": "ok"' in capsys.readouterr().out

--- a/tests/test_tool_configs.py
+++ b/tests/test_tool_configs.py
@@ -1,0 +1,49 @@
+import pytest
+
+from cbrain_cli.cli_utils import CliValidationError
+from cbrain_cli.data.tool_configs import (
+    list_tool_configs,
+    show_tool_config,
+    tool_config_boutiques_descriptor,
+)
+from tests.conftest import make_args as _args
+from tests.conftest import patch_module_locals
+
+
+@pytest.fixture(autouse=True)
+def _patch_locals(monkeypatch):
+    patch_module_locals(monkeypatch, "cbrain_cli.data.tool_configs")
+
+
+def test_list_tool_configs_returns_list(mock_urlopen):
+    mock_urlopen([{"id": 1, "tool_id": 10}])
+    result = list_tool_configs(_args())
+    assert isinstance(result, list)
+    assert result[0]["id"] == 1
+
+
+def test_list_tool_configs_empty_list_is_not_error(mock_urlopen):
+    mock_urlopen([])
+    assert list_tool_configs(_args()) == []
+
+
+def test_show_tool_config_missing_id_raises():
+    with pytest.raises(CliValidationError):
+        show_tool_config(_args(id=None))
+
+
+def test_show_tool_config_returns_dict(mock_urlopen):
+    mock_urlopen({"id": 3, "tool_id": 10})
+    result = show_tool_config(_args(id=3))
+    assert result["id"] == 3
+
+
+def test_tool_config_boutiques_descriptor_missing_id_raises():
+    with pytest.raises(CliValidationError):
+        tool_config_boutiques_descriptor(_args(id=None))
+
+
+def test_tool_config_boutiques_descriptor_returns_dict(mock_urlopen):
+    mock_urlopen({"name": "MyTool", "schema-version": "0.5"})
+    result = tool_config_boutiques_descriptor(_args(id=3))
+    assert result["name"] == "MyTool"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -5,8 +5,7 @@ import pytest
 
 from cbrain_cli.cli_utils import CliApiError, CliValidationError
 from cbrain_cli.data.tools import list_tools, show_tool
-from tests.conftest import make_args
-from tests.conftest import patch_module_locals
+from tests.conftest import make_args, patch_module_locals
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,89 @@
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from cbrain_cli.cli_utils import CliApiError, CliValidationError
+from cbrain_cli.data.tools import list_tools, show_tool
+from tests.conftest import make_args
+from tests.conftest import patch_module_locals
+
+
+@pytest.fixture(autouse=True)
+def _patch_tools_locals(monkeypatch):
+    patch_module_locals(monkeypatch, "cbrain_cli.data.tools")
+
+
+def test_list_tools_passes_page_and_per_page(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(request):
+        captured["url"] = request.full_url
+        mock_http_response = MagicMock()
+        mock_http_response.__enter__.return_value.read.return_value = b"[]"
+        mock_http_response.__exit__.return_value = False
+        return mock_http_response
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    list_tools(make_args(page=2, per_page=10))
+    assert "page=2" in captured["url"]
+    assert "per_page=10" in captured["url"]
+
+
+def test_show_tool_missing_id_raises():
+    with pytest.raises(CliValidationError):
+        show_tool(make_args(id=None))
+
+
+def test_show_tool_finds_tool_on_first_page(monkeypatch):
+    mock_http_response = MagicMock()
+    mock_http_response.__enter__.return_value.read.return_value = json.dumps(
+        [{"id": 3, "name": "MyTool"}, {"id": 4, "name": "Other"}]
+    ).encode()
+    mock_http_response.__exit__.return_value = False
+    monkeypatch.setattr("urllib.request.urlopen", MagicMock(return_value=mock_http_response))
+    result = show_tool(make_args(id=3))
+    assert result["id"] == 3
+    assert result["name"] == "MyTool"
+
+
+def test_show_tool_empty_first_page_raises_cli_api_error(monkeypatch):
+    """Empty first page with no tools raises CliApiError instead of returning None."""
+    mock_http_response = MagicMock()
+    mock_http_response.__enter__.return_value.read.return_value = b"[]"
+    mock_http_response.__exit__.return_value = False
+    monkeypatch.setattr("urllib.request.urlopen", MagicMock(return_value=mock_http_response))
+    with pytest.raises(CliApiError):
+        show_tool(make_args(id=99))
+
+
+def test_show_tool_stops_on_short_page(monkeypatch):
+    """Short page (len < per_page) ends pagination without further requests."""
+    # per_page inside show_tool is hardcoded 20; 1-item page > short-circuit
+    mock_http_response = MagicMock()
+    page_data = json.dumps([{"id": 10, "name": "X"}]).encode()
+    mock_http_response.__enter__.return_value.read.return_value = page_data
+    mock_http_response.__exit__.return_value = False
+    mock_urlopen = MagicMock(return_value=mock_http_response)
+    monkeypatch.setattr("urllib.request.urlopen", mock_urlopen)
+    with pytest.raises(CliApiError):
+        show_tool(make_args(id=99))
+    assert mock_urlopen.call_count == 1
+
+
+def test_show_tool_finds_tool_on_second_page(monkeypatch):
+    first_page_items = [{"id": i, "name": f"T{i}"} for i in range(1, 21)]
+    first_page = MagicMock()
+    first_page.__enter__.return_value.read.return_value = json.dumps(first_page_items).encode()
+    first_page.__exit__.return_value = False
+    second_page = MagicMock()
+    second_page.__enter__.return_value.read.return_value = json.dumps(
+        [{"id": 99, "name": "Target"}]
+    ).encode()
+    second_page.__exit__.return_value = False
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        MagicMock(side_effect=[first_page, second_page]),
+    )
+    result = show_tool(make_args(id=99))
+    assert result["name"] == "Target"

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,83 @@
+import json
+import urllib.error
+from unittest.mock import MagicMock
+
+from cbrain_cli.users import user_details, whoami_user
+from tests.conftest import URL, make_args, parse_json_output, patch_module_locals
+
+
+def test_user_details_http_error_returns_none(monkeypatch, capsys):
+    patch_module_locals(monkeypatch, "cbrain_cli.users")
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        MagicMock(side_effect=urllib.error.HTTPError(URL, 500, "Err", {}, None)),
+    )
+    assert user_details(1) is None
+    assert "Server error (500)" in capsys.readouterr().out
+
+
+def test_user_details_unexpected_error_returns_none(monkeypatch, capsys):
+    patch_module_locals(monkeypatch, "cbrain_cli.users")
+
+    def boom(_req):
+        raise ValueError("parse fail")
+
+    monkeypatch.setattr("urllib.request.urlopen", boom)
+    assert user_details(1) is None
+    assert "Error getting user details" in capsys.readouterr().out
+
+
+def test_whoami_missing_credentials_json(capsys, monkeypatch):
+    monkeypatch.setattr("cbrain_cli.users.user_id", None)
+    monkeypatch.setattr("cbrain_cli.users.cbrain_url", None)
+    monkeypatch.setattr("cbrain_cli.users.api_token", None)
+    assert whoami_user(make_args(json=True)) == 1
+    assert parse_json_output(capsys)["logged_in"] is False
+
+
+def test_whoami_missing_credentials_plain(capsys, monkeypatch):
+    monkeypatch.setattr("cbrain_cli.users.user_id", None)
+    monkeypatch.setattr("cbrain_cli.users.cbrain_url", None)
+    monkeypatch.setattr("cbrain_cli.users.api_token", None)
+    assert whoami_user(make_args()) == 1
+    assert "Credential file is missing" in capsys.readouterr().out
+
+
+def test_whoami_json_output(monkeypatch, capsys):
+    patch_module_locals(monkeypatch, "cbrain_cli.users", user_id=1)
+    monkeypatch.setattr(
+        "cbrain_cli.users.user_details",
+        lambda _: {"login": "admin", "full_name": "Admin User"},
+    )
+    assert whoami_user(make_args(json=True)) == 0
+    result = parse_json_output(capsys)
+    assert result["login"] == "admin"
+    assert result["server"] == URL
+
+
+def test_whoami_plain_output(monkeypatch, capsys):
+    patch_module_locals(monkeypatch, "cbrain_cli.users", user_id=1)
+    monkeypatch.setattr(
+        "cbrain_cli.users.user_details",
+        lambda _: {"login": "admin", "full_name": "Admin User"},
+    )
+    assert whoami_user(make_args()) is None
+    assert "Current user: admin" in capsys.readouterr().out
+
+
+def test_whoami_version_token_mismatch_warning(monkeypatch, capsys):
+    patch_module_locals(monkeypatch, "cbrain_cli.users", user_id=1)
+    monkeypatch.setattr(
+        "cbrain_cli.users.user_details",
+        lambda _: {"login": "admin", "full_name": "Admin User"},
+    )
+    mock_http_response = MagicMock()
+    mock_http_response.__enter__.return_value.read.return_value = json.dumps(
+        {"user_id": 99, "cbrain_api_token": "other-token"}
+    ).encode()
+    mock_http_response.__exit__.return_value = False
+    monkeypatch.setattr("urllib.request.urlopen", MagicMock(return_value=mock_http_response))
+    assert whoami_user(make_args(version=True)) is None
+    out = capsys.readouterr().out
+    assert "WARNING: User ID mismatch" in out
+    assert "Token mismatch" in out


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀

CI runs pre-commit (Ruff, formatting, hooks) and capture tests on every pull request.
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [ ] below with checked ones [x] accordingly. -->

- [X] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [X] I ran `pre-commit run --all-files` and/or `pytest` as appropriate (see [Tests](https://github.com/aces/cbrain-cli/blob/main/README.md#tests) in the README). A clean Ruff/pre-commit run is necessary but not sufficient—behavior still needs tests and review.
- [X] If CLI output changed intentionally, I updated `capture_tests/expected_captures.txt`
- [X] If command behavior changed, I checked normal, `--json`, and `--jsonl` output modes (or noted why not applicable)
- [X] Data-layer modules do not add direct `print()` calls for user-visible output
- [X] Public command names, flags, and default behavior remain compatible unless this PR explicitly documents a breaking change
- [X] No credentials, tokens, or session data appear in code, fixtures, logs, or this PR description

---

### Type of change

- [ ] Bug fix
- [X] New feature or command behavior
- [ ] Documentation
- [X] Tests only
- [X] Other (describe below)
 Protect credentials file permissions
---

### Description
This PR fixes [task 9](https://github.com/aces/cbrain-cli/blob/main/plan.md#9-add-unit-tests-beside-capture-tests) and [task 11](https://github.com/aces/cbrain-cli/blob/main/plan.md#11-protect-credentials-file-permissions) from `plan.md`. Added credential management for file permission also added `pytest` test coverage for the CLI.

<!--
Summarize what this pull request changes and why. For multiple commits, a short overview helps reviewers.

Also consider including:
- User-visible behavior before and after (or "no user-visible change")
- Main files changed and what was done in them
- Whether `capture_tests/expected_captures.txt` was updated for intentional CLI output changes
- How normal, `--json`, and `--jsonl` output behave when command behavior changed
- Whether public command compatibility is preserved or intentionally changed
- Screenshots or a short video, if helpful
-->

---

### Test plan
```bash
pytest --cov=cbrain_cli --cov-report=term-missing
```
<!--
List the commands you ran and what they showed, for example:

- `pre-commit run --all-files`
- `pytest`
- `ruff check .`
- Capture tests (if applicable; see capture_tests/README.md)
- Representative commands with `--json` and `--jsonl` when behavior changed

If you did not run something, say why (e.g. no local CBRAIN server for capture tests).
-->

---

### Related issue

<!-- Link the issue below. Use "Closes #123" to close on merge, or write "No related issue." -->

-Partially Closes #47 
